### PR TITLE
index support + test

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -41,6 +41,9 @@ mutable struct Index
     Index(v::Integer) = v ≥ 1 ? new(v) : error("index must be at least 1")
 end
 Base.:(==)(i::Index, j::Index) = i.val == j.val # needed, as this is not the default behaviour for composite types
+Base.to_index(i::Index) = i.val
+Base.getindex(x::AbstractArray, i::Index) = x[i.val]
+Base.getindex(x::Real, i::Index) = x[i.val]
 
 #
 isnonautonomous(time_dependence::Symbol) = :nonautonomous == time_dependence

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -130,5 +130,7 @@ constraint!(ocp, :dynamics, f) # see previous defs
 @test uub == [ 1 ][uind]
 @test xlb == [ r0, 0, m0 ][xind]
 @test xub == [ Inf, vmax, mf ][xind]
+@test [ Inf, vmax, mf ][Index(2)] == vmax
+@test [ Inf, vmax, mf ][Index(2)][Index(1)] == vmax
 
 end


### PR DESCRIPTION
@BaptisteCbl Also added
```julia
Base.to_index(i::Index) = i.val
Base.getindex(x::AbstractArray, i::Index) = x[i.val]
Base.getindex(x::Real, i::Index) = x[i.val]
```
to encompass sth like
```julia
a = 1
a[Index(1)]
```