### PR TITLE
moved @__def to OptimalControl.jl (simpler)

### DIFF
--- a/src/CTBase.jl
+++ b/src/CTBase.jl
@@ -119,7 +119,6 @@ export Model
 export time!, constraint!, objective!, state!, control!, remove_constraint!, constraint
 export isautonomous, isnonautonomous, ismin, ismax
 export nlp_constraints, constraints_labels
-export @__def
 
 # solution
 export OptimalControlSolution

--- a/src/ctparser_utils.jl
+++ b/src/ctparser_utils.jl
@@ -211,19 +211,3 @@ constraint_type(e, t, t0, tf, x, u) =
 	    (:mixed, ee) end
         _                      => :other
     end
-
-"""
-$(TYPEDSIGNATURES)
-
-Serve as a fake @def macro.
-
-# Example
-
-```jldoctest
-julia> @__def t ∈ [ 0, tf ], time
-```
-"""
-macro __def(e)
-    ocp = Model()
-    :( $ocp )
-end

--- a/test/test_ctparser_utils.jl
+++ b/test/test_ctparser_utils.jl
@@ -43,6 +43,4 @@ t = :t; t0 = 0; tf = :tf; x = :x; u = :u
 @test constraint_type(:( 2u[1](t)^2 * x(t)  ), t, t0, tf, x, u) == (:mixed, :((2 * u[1] ^ 2) * x))
 @test constraint_type(:( 2u[1](0)^2 * x(t)  ), t, t0, tf, x, u) ==  :other
 
-@test (@__def t ∈ [ t0, tf ], time).initial_time == nothing
-
 end


### PR DESCRIPTION
changed my mind to avoid version conflicts between `CTBase.jl`, `OptimalControl.jl` and others. Fake macro `@__def` is now in `OptimalControl.jl` to allow example writing in abstract form.