### PR TITLE
add constructors and calls doc in types.jl and coverage

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Olivier Cots <olivier.cots@enseeiht.fr>"]
 version = "0.7.6"
 
 [deps]
-Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Olivier Cots <olivier.cots@enseeiht.fr>"]
 version = "0.7.6"
 
 [deps]
+Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -290,12 +290,10 @@ Return an ```HamiltonianLift``` of a function.
 Dependencies are specified with a boolean, variable, false by default, autonomous, true by default.
 
 ```@example
-julia> HamiltonianLift(HamiltonianLift(VectorField(x -> [x[1]^2, 2x[2]], Int64))
-IncorrectArgument 
-julia> H = HamiltonianLift(VectorField(x -> [x[1]^2, 2x[2]]))
-julia> H = HamiltonianLift(VectorField((x, v) -> [x[1]^2, 2x[2]+v[3]], variable=true))
-julia> H = HamiltonianLift(VectorField((t, x) -> [t+x[1]^2, 2x[2]], autonomous=false))
-julia> H = HamiltonianLift(VectorField((t, x, v) -> [t+x[1]^2, 2x[2]+v[3]], autonomous=false, variable=true))
+julia> HL = HamiltonianLift(x -> [x[1]^2,x[2]^2], autonomous=true, variable=false)
+julia> HL = HamiltonianLift((x, v) -> [x[1]^2,x[2]^2+v], autonomous=true, variable=true)
+julia> HL = HamiltonianLift((t, x) -> [t+x[1]^2,x[2]^2], autonomous=false, variable=false)
+julia> HL = HamiltonianLift((t, x, v) -> [t+x[1]^2,x[2]^2+v], autonomous=false, variable=true)
 ```
 
 """
@@ -303,7 +301,7 @@ function HamiltonianLift(f::Function;
     autonomous::Bool=true, variable::Bool=false)
     time_dependence = autonomous ? Autonomous : NonAutonomous
     variable_dependence = variable ? NonFixed : Fixed
-    return HamiltonianLift{time_dependence, variable_dependence}(f)
+    return HamiltonianLift(VectorField(f,time_dependence,variable_dependence))
 end
 
 """
@@ -316,10 +314,10 @@ Dependencies are specified with DataType, Autonomous, NonAutonomous and Fixed, N
 ```@example
 julia> HamiltonianLift(HamiltonianLift(VectorField(x -> [x[1]^2, 2x[2]], Int64))
 IncorrectArgument 
-julia> H = HamiltonianLift(VectorField(x -> [x[1]^2, 2x[2]]))
-julia> H = HamiltonianLift(VectorField((x, v) -> [x[1]^2, 2x[2]+v[3]], NonFixed))
-julia> H = HamiltonianLift(VectorField((t, x) -> [t+x[1]^2, 2x[2]], NonAutonomous))
-julia> H = HamiltonianLift(VectorField((t, x, v) -> [t+x[1]^2, 2x[2]+v[3]], NonAutonomous, NonFixed))
+julia> HL = HamiltonianLift(x -> [x[1]^2,x[2]^2], Autonomous, Fixed)
+julia> HL = HamiltonianLift((x, v) -> [x[1]^2,x[2]^2+v], Autonomous, NonFixed)
+julia> HL = HamiltonianLift((t, x) -> [t+x[1]^2,x[2]^2], NonAutonomous, Fixed)
+julia> HL = HamiltonianLift((t, x, v) -> [t+x[1]^2,x[2]^2+v], NonAutonomous, NonFixed)
 ```
 
 """
@@ -327,7 +325,7 @@ function HamiltonianLift(f::Function, dependences::DataType...)
     __check_dependencies(dependences)
     time_dependence = NonAutonomous ∈ dependences ? NonAutonomous : Autonomous
     variable_dependence = NonFixed ∈ dependences ? NonFixed : Fixed
-    return HamiltonianLift{time_dependence, variable_dependence}(f)
+    return HamiltonianLift(VectorField(f,time_dependence,variable_dependence))
 end
 
 """

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -75,7 +75,6 @@ $(TYPEDSIGNATURES)
 Return the evaluation of the BoundaryConstraint at ```x0```, ```xf```, ```v```.
 
 ```@example
-julia> B = BoundaryConstraint((x0, xf) -> [xf[2]-x0[1], 2xf[1]+x0[2]^2])
 julia> B = BoundaryConstraint((x0, xf, v) -> [v[3]+xf[2]-x0[1], v[1]-v[2]+2xf[1]+x0[2]^2], variable=true)
 julia> B([0, 0], [1, 1], [1, 2, 3])
 [4, 1]
@@ -969,14 +968,14 @@ end
 
 $(TYPEDSIGNATURES)
 
-Return the ```StateConstraint``` of a function.
+Return the ```ControlConstraint``` of a function.
 Dependencies are specified with a boolean, variable, false by default, autonomous, true by default.
 
 ```@example
-julia> S = StateConstraint(x -> [x[1]^2, 2x[2]], autonomous=true, variable=false)
-julia> S = StateConstraint((x, v) -> [x[1]^2, 2x[2]+v[3]], autonomous=true, variable=true)
-julia> S = StateConstraint((t, x) -> [t+x[1]^2, 2x[2]], autonomous=false, variable=false)
-julia> S = StateConstraint((t, x, v) -> [t+x[1]^2, 2x[2]+v[3]], autonomous=false, variable=true)
+julia> C = ControlConstraint(u -> [u[1]^2, 2u[2]], autonomous=true, variable=false)
+julia> C = ControlConstraint((u, v) -> [u[1]^2, 2u[2]+v[3]], autonomous=true, variable=true)
+julia> C = ControlConstraint((t, u) -> [t+u[1]^2, 2u[2]], autonomous=false, variable=false)
+julia> C = ControlConstraint((t, u, v) -> [t+u[1]^2, 2u[2]+v[3]], autonomous=false, variable=true)
 ```
 """
 function ControlConstraint(f::Function; 
@@ -1258,8 +1257,10 @@ julia> u([1, 0])
 1
 julia> t = 1
 julia> v = Real[]
-julia> MethodError u(t, [1, 0])
-julia> MethodError u([1, 0], v)
+julia> u(t, [1, 0])
+MethodError
+julia> u([1, 0], v)
+MethodError
 julia> u(t, [1, 0], v)
 1
 julia> u = FeedbackControl((x, v) -> x[1]^2+2x[2]+v[3], autonomous=true, variable=true)
@@ -1368,8 +1369,10 @@ julia> u([1, 0], [0, 1])
 3
 julia> t = 1
 julia> v = Real[]
-julia> MethodError u(t, [1, 0], [0, 1])
-julia> MethodError u([1, 0], [0, 1], v)
+julia> u(t, [1, 0], [0, 1])
+MethodError
+julia> u([1, 0], [0, 1], v)
+MethodError
 julia> u(t, [1, 0], [0, 1], v)
 3
 julia> u = ControlLaw((x, p, v) -> x[1]^2+2p[2]+v[3], autonomous=true, variable=true)
@@ -1469,15 +1472,19 @@ $(TYPEDSIGNATURES)
 Return the value of the Multiplier function.
 
 ```@example
-julia> IncorrectArgument Multiplier((x, p) -> x[1]^2+2p[2], Int64)
-julia> IncorrectArgument Multiplier((x, p) -> x[1]^2+2p[2], Int64)
+julia> Multiplier((x, p) -> x[1]^2+2p[2], Int64)
+IncorrectArgument
+julia> Multiplier((x, p) -> x[1]^2+2p[2], Int64)
+IncorrectArgument
 julia> μ = Multiplier((x, p) -> x[1]^2+2p[2], autonomous=true, variable=false)
 julia> μ([1, 0], [0, 1])
 3
 julia> t = 1
 julia> v = Real[]
-julia> MethodError μ(t, [1, 0], [0, 1])
-julia> MethodError μ([1, 0], [0, 1], v)
+julia> μ(t, [1, 0], [0, 1])
+MethodError
+julia> μ([1, 0], [0, 1], v)
+MethodError
 julia> μ(t, [1, 0], [0, 1], v)
 3
 julia> μ = Multiplier((x, p, v) -> x[1]^2+2p[2]+v[3], autonomous=true, variable=true)

--- a/src/types.jl
+++ b/src/types.jl
@@ -212,8 +212,8 @@ The default values for `time_dependence` and `variable_dependence` are `Autonomo
 The constructor ```VectorField``` returns a ```VectorField``` of a function.
 The function must take 1 to 3 arguments, `x` to `(t, x, v)`, if the function is variable or non autonomous, it must be specified. 
 Dependencies are specified either with :
-    - booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
-    - `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
+- booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
+- `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
 
 ## *Examples*
 
@@ -286,8 +286,8 @@ The default values for `time_dependence` and `variable_dependence` are `Autonomo
 The constructor ```HamiltonianVectorField``` returns a ```HamiltonianVectorField``` of a function.
 The function must take 2 to 4 arguments, `(x, p)` to `(t, x, p, v)`, if the function is variable or non autonomous, it must be specified. 
 Dependencies are specified either with :
-    - booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
-    - `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
+- booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
+- `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
 
 ## *Examples*
 
@@ -409,6 +409,15 @@ julia> H(1, [1, 0], [0, 1], [1, 2, 3])
 3
 ```
 
+Alternatively, it is possible to construct the `HamiltonianLift` from a `Function` being the `VectorField`.
+
+```@example
+julia> HL1 = HamiltonianLift((x, v) -> [x[1]^2,x[2]^2+v], autonomous=true, variable=true)
+julia> HL2 = HamiltonianLift(VectorField((x, v) -> [x[1]^2,x[2]^2+v], autonomous=true, variable=true))
+julia> HL1([1, 0], [0, 1], 1) == HL2([1, 0], [0, 1], 1)
+true
+```
+
 """
 struct HamiltonianLift{time_dependence,variable_dependence}  <: AbstractHamiltonian{time_dependence,variable_dependence}
     X::VectorField
@@ -431,8 +440,8 @@ The default value for `time_dependence` and `variable_dependence` are `Autonomou
 The constructor ```Lagrange``` returns a ```Lagrange``` cost of a function.
 The function must take 2 to 4 arguments, `(x, u)` to `(t, x, u, v)`, if the function is variable or non autonomous, it must be specified. 
 Dependencies are specified either with :
-    - booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
-    - `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
+- booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
+- `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
 
 ## *Examples*
 
@@ -512,8 +521,8 @@ The default value for `time_dependence` and `variable_dependence` are `Autonomou
 The constructor ```Dynamics``` returns a ```Dynamics``` of a function.
 The function must take 2 to 4 arguments, `(x, u)` to `(t, x, u, v)`, if the function is variable or non autonomous, it must be specified. 
 Dependencies are specified either with :
-    - booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
-    - `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
+- booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
+- `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
 
 ## *Examples*
 
@@ -587,8 +596,8 @@ The default values for `time_dependence` and `variable_dependence` are `Autonomo
 The constructor ```StateConstraint``` returns a ```StateConstraint``` of a function.
 The function must take 1 to 3 arguments, `x` to `(t, x, v)`, if the function is variable or non autonomous, it must be specified. 
 Dependencies are specified either with :
-    - booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
-    - `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
+- booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
+- `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
 
 ## *Examples*
 
@@ -665,8 +674,8 @@ The default values for `time_dependence` and `variable_dependence` are `Autonomo
 The constructor ```ControlConstraint``` returns a ```ControlConstraint``` of a function.
 The function must take 1 to 3 arguments, `u` to `(t, u, v)`, if the function is variable or non autonomous, it must be specified. 
 Dependencies are specified either with :
-    - booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
-    - `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
+- booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
+- `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
 
 ## *Examples*
 
@@ -738,8 +747,8 @@ The default value for `time_dependence` and `variable_dependence` are `Autonomou
 The constructor ```MixedConstraint``` returns a ```MixedConstraint``` of a function.
 The function must take 2 to 4 arguments, `(x, u)` to `(t, x, u, v)`, if the function is variable or non autonomous, it must be specified. 
 Dependencies are specified either with :
-    - booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
-    - `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
+- booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
+- `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
 
 ## *Examples*
 
@@ -861,8 +870,8 @@ The default values for `time_dependence` and `variable_dependence` are `Autonomo
 The constructor ```FeedbackControl``` returns a ```FeedbackControl``` of a function.
 The function must take 1 to 3 arguments, `x` to `(t, x, v)`, if the function is variable or non autonomous, it must be specified. 
 Dependencies are specified either with :
-    - booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
-    - `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
+- booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
+- `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
 
 ## *Examples*
 
@@ -940,8 +949,8 @@ The default values for `time_dependence` and `variable_dependence` are `Autonomo
 The constructor ```ControlLaw``` returns a ```ControlLaw``` of a function.
 The function must take 2 to 4 arguments, `(x, p)` to `(t, x, p, v)`, if the function is variable or non autonomous, it must be specified. 
 Dependencies are specified either with :
-    - booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
-    - `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
+- booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
+- `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
 
 ## *Examples*
 
@@ -1019,8 +1028,8 @@ The default values for `time_dependence` and `variable_dependence` are `Autonomo
 The constructor ```Multiplier``` returns a ```Multiplier``` of a function.
 The function must take 2 to 4 arguments, `(x, p)` to `(t, x, p, v)`, if the function is variable or non autonomous, it must be specified. 
 Dependencies are specified either with :
-    - booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
-    - `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
+- booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
+- `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
 
 ## *Examples*
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -17,22 +17,42 @@ $(TYPEDFIELDS)
 
 The default value for `variable_dependence` is `Fixed`.
 
+## Constructor
+
+The constructor ```BoundaryConstraint``` returns a ```BoundaryConstraint``` of a function.
+The function must take 2 or 3 arguments `(x0, xf)` or `(x0, xf, v)`, if the function is variable, it must be specified. 
+Dependencies are specified with a boolean, `variable`, `false` by default or with a `DataType`, `NonFixed/Fixed`, `Fixed` by default.
+
+## *Examples*
+
+```@example
+julia> B = BoundaryConstraint((x0, xf) -> [xf[2]-x0[1], 2xf[1]+x0[2]^2])
+julia> B = BoundaryConstraint((x0, xf, v) -> [v[3]+xf[2]-x0[1], v[1]-v[2]+2xf[1]+x0[2]^2], variable=true)
+julia> B = BoundaryConstraint((x0, xf, v) -> [v[3]+xf[2]-x0[1], v[1]-v[2]+2xf[1]+x0[2]^2], NonFixed)
+```
 !!! warning
 
     When the state is of dimension 1, consider `x0` and `xf` as a scalar. When the constraint is dimension 1, return a scalar.
 
-## Examples
+## Call
+
+The call returns the evaluation of the `BoundaryConstraint` for given values.
+If a variable is given for a non variable dependent boundary constraint, it will be ignored.
+
+## *Examples*
 
 ```@example
-julia> B = BoundaryConstraint((x0, xf) -> [xf[2]-x0[1], 2xf[1]+x0[2]^2]) # variable=false by default
+julia> B = BoundaryConstraint((x0, xf) -> [xf[2]-x0[1], 2xf[1]+x0[2]^2])
 julia> B([0, 0], [1, 1])
 [1, 2]
+julia> B = BoundaryConstraint((x0, xf) -> [xf[2]-x0[1], 2xf[1]+x0[2]^2])
 julia> B([0, 0], [1, 1],Real[])
 [1, 2]
 julia> B = BoundaryConstraint((x0, xf, v) -> [v[3]+xf[2]-x0[1], v[1]-v[2]+2xf[1]+x0[2]^2], variable=true)
 julia> B([0, 0], [1, 1], [1, 2, 3])
 [4, 1]
 ```
+
 """
 struct BoundaryConstraint{variable_dependence}
     f::Function
@@ -47,25 +67,44 @@ $(TYPEDFIELDS)
 
 The default value for `variable_dependence` is `Fixed`.
 
+## Constructor
+
+The constructor ```Mayer``` returns a ```Mayer``` cost of a function.
+The function must take 2 or 3 arguments `(x0, xf)` or `(x0, xf, v)`, if the function is variable, it must be specified. 
+Dependencies are specified with a boolean, `variable`, `false` by default or with a `DataType`, `NonFixed/Fixed`, `Fixed` by default.
+
+## *Examples*
+
+```@example
+julia> G = Mayer((x0, xf) -> xf[2]-x0[1])
+julia> G = Mayer((x0, xf, v) -> v[3]+xf[2]-x0[1], variable=true)
+julia> G = Mayer((x0, xf, v) -> v[3]+xf[2]-x0[1], NonFixed)
+```
+
 !!! warning
 
     When the state is of dimension 1, consider `x0` and `xf` as a scalar.
 
-## Examples
+## Call
+
+The call returns the evaluation of the `Mayer` cost for given values.
+If a variable is given for a non variable dependent Mayer cost, it will be ignored.
+
+## *Examples*
 
 ```@example
-julia> G = Mayer((x0, xf) -> [xf[2]-x0[1]]) # variable=false by default
-julia> G([0, 0], [1, 1])
-MethodError
 julia> G = Mayer((x0, xf) -> xf[2]-x0[1])
 julia> G([0, 0], [1, 1])
 1
+julia> G = Mayer((x0, xf) -> xf[2]-x0[1])
 julia> G([0, 0], [1, 1],Real[])
 1
 julia> G = Mayer((x0, xf, v) -> v[3]+xf[2]-x0[1], variable=true)
 julia> G([0, 0], [1, 1], [1, 2, 3])
 4
 ```
+
+
 """
 struct Mayer{variable_dependence}
     f::Function
@@ -94,17 +133,37 @@ $(TYPEDFIELDS)
 
 The default values for `time_dependence` and `variable_dependence` are `Autonomous` and `Fixed` respectively.
 
-!!! warning
+## Constructor
 
-    When the state and costate are of dimension 1, consider `x` and `p` as scalars.
+The constructor ```Hamiltonian``` returns a ```Hamiltonian``` of a function.
+The function must take 2 to 4 arguments, `(x, p)` to `(t, x, p, v)`, if the function is variable or non autonomous, it must be specified. 
+Dependencies are specified either with :
+ - booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
+ - `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
 
-## Examples
+## *Examples*
 
 ```@example
 julia> Hamiltonian((x, p) -> x + p, Int64)
 IncorrectArgument 
 julia> Hamiltonian((x, p) -> x + p, Int64)
 IncorrectArgument
+julia> H = Hamiltonian((x, p) -> x[1]^2+2p[2])
+julia> H = Hamiltonian((t, x, p, v) -> [t+x[1]^2+2p[2]+v[3]], autonomous=false, variable=true)
+julia> H = Hamiltonian((t, x, p, v) -> [t+x[1]^2+2p[2]+v[3]], NonAutonomous, NonFixed)
+```
+
+!!! warning
+
+    When the state and costate are of dimension 1, consider `x` and `p` as scalars.
+
+## Call
+
+The call returns the evaluation of the `Hamiltonian` for given values.
+
+## *Examples*
+
+```@example
 julia> H = Hamiltonian((x, p) -> [x[1]^2+2p[2]]) # autonomous=true, variable=false
 julia> H([1, 0], [0, 1])
 MethodError # H must return a scalar
@@ -133,6 +192,7 @@ julia> H = Hamiltonian((t, x, p, v) -> t+x[1]^2+2p[2]+v[3], autonomous=false, va
 julia> H(1, [1, 0], [0, 1], [1, 2, 3])
 7
 ```
+    
 """
 struct Hamiltonian{time_dependence, variable_dependence} <: AbstractHamiltonian{time_dependence, variable_dependence}
     f::Function
@@ -145,19 +205,43 @@ $(TYPEDEF)
 
 $(TYPEDFIELDS)
 
-The default value for `time_dependence` and `variable_dependence` are `Autonomous` and `Fixed` respectively.
+The default values for `time_dependence` and `variable_dependence` are `Autonomous` and `Fixed` respectively.
 
-!!! warning
+## Constructor
 
-    When the state is of dimension 1, consider `x` as a scalar.
+The constructor ```VectorField``` returns a ```VectorField``` of a function.
+The function must take 1 to 3 arguments, `x` to `(t, x, v)`, if the function is variable or non autonomous, it must be specified. 
+Dependencies are specified either with :
+    - booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
+    - `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
 
-## Examples
+## *Examples*
 
 ```@example
 julia> VectorField(x -> [x[1]^2, 2x[2]], Int64)
 IncorrectArgument
 julia> VectorField(x -> [x[1]^2, 2x[2]], Int64)
 IncorrectArgument
+julia> V = VectorField(x -> [x[1]^2, 2x[2]]) # autonomous=true, variable=false
+julia> V = VectorField((x, v) -> [x[1]^2, 2x[2]+v[3]], variable=true)
+julia> V = VectorField((t, x) -> [t+x[1]^2, 2x[2]], autonomous=false)
+julia> V = VectorField((t, x, v) -> [t+x[1]^2, 2x[2]+v[3]], autonomous=false, variable=true)
+julia> V = VectorField((x, v) -> [x[1]^2, 2x[2]+v[3]], NonFixed)
+julia> V = VectorField((t, x) -> [t+x[1]^2, 2x[2]], NonAutonomous)
+julia> V = VectorField((t, x, v) -> [t+x[1]^2, 2x[2]+v[3]], NonAutonomous, NonFixed)
+```
+
+!!! warning
+
+    When the state is of dimension 1, consider `x` as a scalar.
+
+## Call
+
+The call returns the evaluation of the `VectorField` for given values.
+
+## *Examples*
+
+```@example
 julia> V = VectorField(x -> [x[1]^2, 2x[2]]) # autonomous=true, variable=false
 julia> V([1, -1])
 [1, -2]
@@ -197,17 +281,41 @@ $(TYPEDFIELDS)
 
 The default values for `time_dependence` and `variable_dependence` are `Autonomous` and `Fixed` respectively.
 
-!!! warning
+## Constructor
 
-    When the state and costate are of dimension 1, consider `x` and `p` as scalars.
+The constructor ```HamiltonianVectorField``` returns a ```HamiltonianVectorField``` of a function.
+The function must take 2 to 4 arguments, `(x, p)` to `(t, x, p, v)`, if the function is variable or non autonomous, it must be specified. 
+Dependencies are specified either with :
+    - booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
+    - `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
 
-## Examples
+## *Examples*
 
 ```@example
 julia> HamiltonianVectorField((x, p) -> [x[1]^2+2p[2], x[2]-3p[2]^2], Int64)
 IncorrectArgument
 julia> HamiltonianVectorField((x, p) -> [x[1]^2+2p[2], x[2]-3p[2]^2], Int64)
 IncorrectArgument
+julia> Hv = HamiltonianVectorField((x, p) -> [x[1]^2+2p[2], x[2]-3p[2]^2]) # autonomous=true, variable=false
+julia> Hv = HamiltonianVectorField((x, p, v) -> [x[1]^2+2p[2]+v[3], x[2]-3p[2]^2+v[4]], variable=true)
+julia> Hv = HamiltonianVectorField((t, x, p) -> [t+x[1]^2+2p[2], x[2]-3p[2]^2], autonomous=false)
+julia> Hv = HamiltonianVectorField((t, x, p, v) -> [t+x[1]^2+2p[2]+v[3], x[2]-3p[2]^2+v[4]], autonomous=false, variable=true)
+julia> Hv = HamiltonianVectorField((x, p, v) -> [x[1]^2+2p[2]+v[3], x[2]-3p[2]^2+v[4]], NonFixed)
+julia> Hv = HamiltonianVectorField((t, x, p) -> [t+x[1]^2+2p[2], x[2]-3p[2]^2], NonAutonomous)
+julia> Hv = HamiltonianVectorField((t, x, p, v) -> [t+x[1]^2+2p[2]+v[3], x[2]-3p[2]^2+v[4]], NonAutonomous, NonFixed)
+```
+
+!!! warning
+
+    When the state and costate are of dimension 1, consider `x` and `p` as scalars.
+
+## Call
+
+The call returns the evaluation of the `HamiltonianVectorField` for given values.
+
+## *Examples*
+
+```@example
 julia> Hv = HamiltonianVectorField((x, p) -> [x[1]^2+2p[2], x[2]-3p[2]^2]) # autonomous=true, variable=false
 julia> Hv([1, 0], [0, 1])
 [3, -3]
@@ -247,15 +355,34 @@ $(TYPEDFIELDS)
 
 The values for `time_dependence` and `variable_dependence` are deternimed by the values of those for the VectorField.
 
+## Constructor
+
+The constructor ```HamiltonianLift``` returns a ```HamiltonianLift``` of a `VectorField`.
+
+## *Examples*
+
+```@example
+julia> H = HamiltonianLift(VectorField(x -> [x[1]^2, 2x[2]]))
+julia> H = HamiltonianLift(VectorField((x, v) -> [x[1]^2, 2x[2]+v[3]], variable=true))
+julia> H = HamiltonianLift(VectorField((t, x) -> [t+x[1]^2, 2x[2]], autonomous=false))
+julia> H = HamiltonianLift(VectorField((t, x, v) -> [t+x[1]^2, 2x[2]+v[3]], autonomous=false, variable=true))
+julia> H = HamiltonianLift(VectorField(x -> [x[1]^2, 2x[2]]))
+julia> H = HamiltonianLift(VectorField((x, v) -> [x[1]^2, 2x[2]+v[3]], NonFixed))
+julia> H = HamiltonianLift(VectorField((t, x) -> [t+x[1]^2, 2x[2]], NonAutonomous))
+julia> H = HamiltonianLift(VectorField((t, x, v) -> [t+x[1]^2, 2x[2]+v[3]], NonAutonomous, NonFixed))
+```
+
 !!! warning
 
     When the state and costate are of dimension 1, consider `x` and `p` as scalars.
 
-## Examples
+## Call
+
+The call returns the evaluation of the `HamiltonianLift` for given values.
+
+## *Examples*
 
 ```@example
-julia> HamiltonianLift(HamiltonianLift(VectorField(x -> [x[1]^2, 2x[2]], Int64))
-IncorrectArgument 
 julia> H = HamiltonianLift(VectorField(x -> [x[1]^2, 2x[2]]))
 julia> H([1, 2], [1, 1])
 5
@@ -281,6 +408,7 @@ julia> H = HamiltonianLift(VectorField((t, x, v) -> [t+x[1]^2, 2x[2]+v[3]], auto
 julia> H(1, [1, 0], [0, 1], [1, 2, 3])
 3
 ```
+
 """
 struct HamiltonianLift{time_dependence,variable_dependence}  <: AbstractHamiltonian{time_dependence,variable_dependence}
     X::VectorField
@@ -298,17 +426,44 @@ $(TYPEDFIELDS)
 
 The default value for `time_dependence` and `variable_dependence` are `Autonomous` and `Fixed` respectively.
 
-!!! warning
+## Constructor
 
-    When the state is of dimension 1, consider `x` as a scalar. Same for the control.
+The constructor ```Lagrange``` returns a ```Lagrange``` cost of a function.
+The function must take 2 to 4 arguments, `(x, u)` to `(t, x, u, v)`, if the function is variable or non autonomous, it must be specified. 
+Dependencies are specified either with :
+    - booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
+    - `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
 
-## Examples
+## *Examples*
 
 ```@example
 julia> Lagrange((x, u) -> 2x[2]-u[1]^2, Int64)
 IncorrectArgument
 julia> Lagrange((x, u) -> 2x[2]-u[1]^2, Int64)
 IncorrectArgument
+julia> L = Lagrange((x, u) -> [2x[2]-u[1]^2], autonomous=true, variable=false)
+julia> L = Lagrange((x, u) -> 2x[2]-u[1]^2, autonomous=true, variable=false)
+julia> L = Lagrange((x, u, v) -> 2x[2]-u[1]^2+v[3], autonomous=true, variable=true)
+julia> L = Lagrange((t, x, u) -> t+2x[2]-u[1]^2, autonomous=false, variable=false)
+julia> L = Lagrange((t, x, u, v) -> t+2x[2]-u[1]^2+v[3], autonomous=false, variable=true)
+julia> L = Lagrange((x, u) -> [2x[2]-u[1]^2], Autonomous, Fixed)
+julia> L = Lagrange((x, u) -> 2x[2]-u[1]^2, Autonomous, Fixed)
+julia> L = Lagrange((x, u, v) -> 2x[2]-u[1]^2+v[3], Autonomous, NonFixed)
+julia> L = Lagrange((t, x, u) -> t+2x[2]-u[1]^2, autonomous=false, Fixed)
+julia> L = Lagrange((t, x, u, v) -> t+2x[2]-u[1]^2+v[3], autonomous=false, NonFixed)
+```
+
+!!! warning
+
+    When the state is of dimension 1, consider `x` as a scalar. Same for the control.
+
+## Call
+
+The call returns the evaluation of the `Lagrange` cost for given values.
+
+## *Examples*
+
+```@example
 julia> L = Lagrange((x, u) -> [2x[2]-u[1]^2], autonomous=true, variable=false)
 julia> L([1, 0], [1])
 MethodError
@@ -350,7 +505,65 @@ $(TYPEDEF)
 
 $(TYPEDFIELDS)
 
-Similar to `Lagrange`, but the function `f` is assumed to return a vector of the same dimension as the state `x`.
+The default value for `time_dependence` and `variable_dependence` are `Autonomous` and `Fixed` respectively.
+
+## Constructor
+
+The constructor ```Dynamics``` returns a ```Dynamics``` of a function.
+The function must take 2 to 4 arguments, `(x, u)` to `(t, x, u, v)`, if the function is variable or non autonomous, it must be specified. 
+Dependencies are specified either with :
+    - booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
+    - `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
+
+## *Examples*
+
+```@example
+julia> Dynamics((x, u) -> [2x[2]-u^2, x[1]], Int64)
+IncorrectArgument
+julia> Dynamics((x, u) -> [2x[2]-u^2, x[1]], Int64)
+IncorrectArgument
+julia> D = Dynamics((x, u) -> [2x[2]-u^2, x[1]], Autonomous, Fixed)
+julia> D = Dynamics((x, u, v) -> [2x[2]-u^2+v[3], x[1]], Autonomous, NonFixed)
+julia> D = Dynamics((t, x, u) -> [t+2x[2]-u^2, x[1]], NonAutonomous, Fixed)
+julia> D = Dynamics((t, x, u, v) -> [t+2x[2]-u^2+v[3], x[1]], NonAutonomous, NonFixed)
+julia> D = Dynamics((x, u) -> [2x[2]-u^2, x[1]], autonomous=true, variable=false)
+julia> D = Dynamics((x, u, v) -> [2x[2]-u^2+v[3], x[1]], autonomous=true, variable=true)
+julia> D = Dynamics((t, x, u) -> [t+2x[2]-u^2, x[1]], autonomous=false, variable=false)
+julia> D = Dynamics((t, x, u, v) -> [t+2x[2]-u^2+v[3], x[1]], autonomous=false, variable=true)
+```
+
+!!! warning
+
+    When the state is of dimension 1, consider `x` as a scalar. Same for the control.
+
+## Call
+
+The call returns the evaluation of the `Dynamics` for given values.
+
+## *Examples*
+
+```@example
+julia> D = Dynamics((x, u) -> [2x[2]-u^2, x[1]], autonomous=true, variable=false)
+julia> D([1, 0], 1)
+[-1, 1]
+julia> t = 1
+julia> v = Real[]
+julia> D(t, [1, 0], 1, v)
+[-1, 1]
+julia> D = Dynamics((x, u, v) -> [2x[2]-u^2+v[3], x[1]], autonomous=true, variable=true)
+julia> D([1, 0], 1, [1, 2, 3])
+[2, 1]
+julia> D(t, [1, 0], 1, [1, 2, 3])
+[2, 1]
+julia> D = Dynamics((t, x, u) -> [t+2x[2]-u^2, x[1]], autonomous=false, variable=false)
+julia> D(1, [1, 0], 1)
+[0, 1]
+julia> D(1, [1, 0], 1, v)
+[0, 1]
+julia> D = Dynamics((t, x, u, v) -> [t+2x[2]-u^2+v[3], x[1]], autonomous=false, variable=true)
+julia> D(1, [1, 0], 1, [1, 2, 3])
+[3, 1]
+```
 
 """
 struct Dynamics{time_dependence, variable_dependence}
@@ -367,6 +580,70 @@ $(TYPEDFIELDS)
 
 Similar to `VectorField` in the usage, but the dimension of the output of the function `f` is arbitrary.
 
+The default values for `time_dependence` and `variable_dependence` are `Autonomous` and `Fixed` respectively.
+
+## Constructor
+
+The constructor ```StateConstraint``` returns a ```StateConstraint``` of a function.
+The function must take 1 to 3 arguments, `x` to `(t, x, v)`, if the function is variable or non autonomous, it must be specified. 
+Dependencies are specified either with :
+    - booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
+    - `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
+
+## *Examples*
+
+```@example
+julia> StateConstraint(x -> [x[1]^2, 2x[2]], Int64)
+IncorrectArgument
+julia> StateConstraint(x -> [x[1]^2, 2x[2]], Int64)
+IncorrectArgument
+julia> S = StateConstraint(x -> [x[1]^2, 2x[2]], Autonomous, Fixed)
+julia> S = StateConstraint((x, v) -> [x[1]^2, 2x[2]+v[3]], Autonomous, NonFixed)
+julia> S = StateConstraint((t, x) -> [t+x[1]^2, 2x[2]], NonAutonomous, Fixed)
+julia> S = StateConstraint((t, x, v) -> [t+x[1]^2, 2x[2]+v[3]], NonAutonomous, NonFixed)
+julia> S = StateConstraint(x -> [x[1]^2, 2x[2]], autonomous=true, variable=false)
+julia> S = StateConstraint((x, v) -> [x[1]^2, 2x[2]+v[3]], autonomous=true, variable=true)
+julia> S = StateConstraint((t, x) -> [t+x[1]^2, 2x[2]], autonomous=false, variable=false)
+julia> S = StateConstraint((t, x, v) -> [t+x[1]^2, 2x[2]+v[3]], autonomous=false, variable=true)
+```
+
+!!! warning
+
+    When the state is of dimension 1, consider `x` as a scalar.
+
+## Call
+
+The call returns the evaluation of the `StateConstraint` for given values.
+
+## *Examples*
+
+```@example
+julia> StateConstraint(x -> [x[1]^2, 2x[2]], Int64)
+IncorrectArgument
+julia> StateConstraint(x -> [x[1]^2, 2x[2]], Int64)
+IncorrectArgument
+julia> S = StateConstraint(x -> [x[1]^2, 2x[2]], autonomous=true, variable=false)
+julia> S([1, -1])
+[1, -2]
+julia> t = 1
+julia> v = Real[]
+julia> S(t, [1, -1], v)
+[1, -2]
+julia> S = StateConstraint((x, v) -> [x[1]^2, 2x[2]+v[3]], autonomous=true, variable=true)
+julia> S([1, -1], [1, 2, 3])
+[1, 1]
+julia> S(t, [1, -1], [1, 2, 3])
+[1, 1]
+julia> S = StateConstraint((t, x) -> [t+x[1]^2, 2x[2]], autonomous=false, variable=false)
+julia>  S(1, [1, -1])
+[2, -2]
+julia>  S(1, [1, -1], v)
+[2, -2]
+julia> S = StateConstraint((t, x, v) -> [t+x[1]^2, 2x[2]+v[3]], autonomous=false, variable=true)
+julia>  S(1, [1, -1], [1, 2, 3])
+[2, 1]
+```
+
 """
 struct StateConstraint{time_dependence, variable_dependence}
     f::Function
@@ -380,6 +657,64 @@ $(TYPEDEF)
 $(TYPEDFIELDS)
 
 Similar to `VectorField` in the usage, but the dimension of the output of the function `f` is arbitrary.
+
+The default values for `time_dependence` and `variable_dependence` are `Autonomous` and `Fixed` respectively.
+
+## Constructor
+
+The constructor ```ControlConstraint``` returns a ```ControlConstraint``` of a function.
+The function must take 1 to 3 arguments, `u` to `(t, u, v)`, if the function is variable or non autonomous, it must be specified. 
+Dependencies are specified either with :
+    - booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
+    - `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
+
+## *Examples*
+
+```@example
+julia> IncorrectArgument ControlConstraint(u -> [u[1]^2, 2u[2]], Int64)
+julia> IncorrectArgument ControlConstraint(u -> [u[1]^2, 2u[2]], Int64)
+julia> C = ControlConstraint(u -> [u[1]^2, 2u[2]], Autonomous, Fixed)
+julia> C = ControlConstraint((u, v) -> [u[1]^2, 2u[2]+v[3]], Autonomous, NonFixed)
+julia> C = ControlConstraint((t, u) -> [t+u[1]^2, 2u[2]], NonAutonomous, Fixed)
+julia> C = ControlConstraint((t, u, v) -> [t+u[1]^2, 2u[2]+v[3]], NonAutonomous, NonFixed)
+julia> C = ControlConstraint(u -> [u[1]^2, 2u[2]], autonomous=true, variable=false)
+julia> C = ControlConstraint((u, v) -> [u[1]^2, 2u[2]+v[3]], autonomous=true, variable=true)
+julia> C = ControlConstraint((t, u) -> [t+u[1]^2, 2u[2]], autonomous=false, variable=false)
+julia> C = ControlConstraint((t, u, v) -> [t+u[1]^2, 2u[2]+v[3]], autonomous=false, variable=true)
+```
+
+!!! warning
+
+    When the control is of dimension 1, consider `u` as a scalar.
+
+## Call
+
+The call returns the evaluation of the `ControlConstraint` for given values.
+
+## *Examples*
+
+```@example
+julia> C = ControlConstraint(u -> [u[1]^2, 2u[2]], autonomous=true, variable=false)
+julia> C([1, -1])
+[1, -2]
+julia> t = 1
+julia> v = Real[]
+julia> C(t, [1, -1], v)
+[1, -2]
+julia> C = ControlConstraint((u, v) -> [u[1]^2, 2u[2]+v[3]], autonomous=true, variable=true)
+julia> C([1, -1], [1, 2, 3])
+[1, 1]
+julia> C(t, [1, -1], [1, 2, 3])
+[1, 1]
+julia> C = ControlConstraint((t, u) -> [t+u[1]^2, 2u[2]], autonomous=false, variable=false)
+julia> C(1, [1, -1])
+[2, -2]
+julia> C(1, [1, -1], v)
+[2, -2]
+julia> C = ControlConstraint((t, u, v) -> [t+u[1]^2, 2u[2]+v[3]], autonomous=false, variable=true)
+julia> C(1, [1, -1], [1, 2, 3])
+[2, 1]
+```
 
 """
 struct ControlConstraint{time_dependence, variable_dependence}
@@ -396,6 +731,72 @@ $(TYPEDFIELDS)
 
 Similar to `Lagrange` in the usage, but the dimension of the output of the function `f` is arbitrary.
 
+The default value for `time_dependence` and `variable_dependence` are `Autonomous` and `Fixed` respectively.
+
+## Constructor
+
+The constructor ```MixedConstraint``` returns a ```MixedConstraint``` of a function.
+The function must take 2 to 4 arguments, `(x, u)` to `(t, x, u, v)`, if the function is variable or non autonomous, it must be specified. 
+Dependencies are specified either with :
+    - booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
+    - `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
+
+## *Examples*
+
+```@example
+julia> MixedConstraint((x, u) -> [2x[2]-u^2, x[1]], Int64)
+IncorrectArgument
+julia> MixedConstraint((x, u) -> [2x[2]-u^2, x[1]], Int64)
+IncorrectArgument
+julia> M = MixedConstraint((x, u) -> [2x[2]-u^2, x[1]], Autonomous, Fixed)
+julia> M = MixedConstraint((x, u, v) -> [2x[2]-u^2+v[3], x[1]], Autonomous, NonFixed)
+julia> M = MixedConstraint((t, x, u) -> [t+2x[2]-u^2, x[1]], NonAutonomous, Fixed)
+julia> M = MixedConstraint((t, x, u, v) -> [t+2x[2]-u^2+v[3], x[1]], NonAutonomous, NonFixed)
+julia> M = MixedConstraint((x, u) -> [2x[2]-u^2, x[1]], autonomous=true, variable=false)
+julia> M = MixedConstraint((x, u, v) -> [2x[2]-u^2+v[3], x[1]], autonomous=true, variable=true)
+julia> M = MixedConstraint((t, x, u) -> [t+2x[2]-u^2, x[1]], autonomous=false, variable=false)
+julia> M = MixedConstraint((t, x, u, v) -> [t+2x[2]-u^2+v[3], x[1]], autonomous=false, variable=true)
+```
+
+!!! warning
+
+    When the state is of dimension 1, consider `x` as a scalar. Same for the control.
+
+## Call
+
+The call returns the evaluation of the `MixedConstraint` for given values.
+
+## *Examples*
+
+```@example
+julia> MixedConstraint((x, u) -> [2x[2]-u^2, x[1]], Int64)
+IncorrectArgument
+julia> MixedConstraint((x, u) -> [2x[2]-u^2, x[1]], Int64)
+IncorrectArgument
+julia> M = MixedConstraint((x, u) -> [2x[2]-u^2, x[1]], autonomous=true, variable=false)
+julia> M([1, 0], 1)
+[-1, 1]
+julia> t = 1
+julia> v = Real[]
+julia> MethodError M(t, [1, 0], 1)
+julia> MethodError M([1, 0], 1, v)
+julia> M(t, [1, 0], 1, v)
+[-1, 1]
+julia> M = MixedConstraint((x, u, v) -> [2x[2]-u^2+v[3], x[1]], autonomous=true, variable=true)
+julia> M([1, 0], 1, [1, 2, 3])
+[2, 1]
+julia> M(t, [1, 0], 1, [1, 2, 3])
+[2, 1]
+julia> M = MixedConstraint((t, x, u) -> [t+2x[2]-u^2, x[1]], autonomous=false, variable=false)
+julia> M(1, [1, 0], 1)
+[0, 1]
+julia> M(1, [1, 0], 1, v)
+[0, 1]
+julia> M = MixedConstraint((t, x, u, v) -> [t+2x[2]-u^2+v[3], x[1]], autonomous=false, variable=true)
+julia> M(1, [1, 0], 1, [1, 2, 3])
+[3, 1]
+```
+
 """
 struct MixedConstraint{time_dependence, variable_dependence}
     f::Function
@@ -409,9 +810,34 @@ $(TYPEDEF)
 
 $(TYPEDFIELDS)
 
+The default values for `time_dependence` and `variable_dependence` are `Autonomous` and `Fixed` respectively.
+
+## Constructor
+
+The constructor ```VariableConstraint``` returns a ```VariableConstraint``` of a function.
+The function must take 1 argument, `v`.
+
+## *Examples*
+
+```@example
+julia> V = VariableConstraint(v -> [v[1]^2, 2v[2]])
+```
+
 !!! warning
 
     When the variable is of dimension 1, consider `v` as a scalar.
+
+## Call
+
+The call returns the evaluation of the `VariableConstraint` for given values.
+
+## *Examples*
+
+```@example
+julia> V = VariableConstraint(v -> [v[1]^2, 2v[2]])
+julia> V([1, -1])
+[1, -2]
+```
 
 """
 struct VariableConstraint
@@ -428,6 +854,70 @@ $(TYPEDFIELDS)
 
 Similar to `VectorField` in the usage, but the dimension of the output of the function `f` is arbitrary.
 
+The default values for `time_dependence` and `variable_dependence` are `Autonomous` and `Fixed` respectively.
+
+## Constructor
+
+The constructor ```FeedbackControl``` returns a ```FeedbackControl``` of a function.
+The function must take 1 to 3 arguments, `x` to `(t, x, v)`, if the function is variable or non autonomous, it must be specified. 
+Dependencies are specified either with :
+    - booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
+    - `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
+
+## *Examples*
+
+```@example
+julia> FeedbackControl(x -> x[1]^2+2x[2], Int64)
+IncorrectArgument
+julia> FeedbackControl(x -> x[1]^2+2x[2], Int64)
+IncorrectArgument
+julia> u = FeedbackControl(x -> x[1]^2+2x[2], Autonomous, Fixed)
+julia> u = FeedbackControl((x, v) -> x[1]^2+2x[2]+v[3], Autonomous, NonFixed)
+julia> u = FeedbackControl((t, x) -> t+x[1]^2+2x[2], NonAutonomous, Fixed)
+julia> u = FeedbackControl((t, x, v) -> t+x[1]^2+2x[2]+v[3], NonAutonomous, NonFixed)
+julia> u = FeedbackControl(x -> x[1]^2+2x[2], autonomous=true, variable=false)
+julia> u = FeedbackControl((x, v) -> x[1]^2+2x[2]+v[3], autonomous=true, variable=true)
+julia> u = FeedbackControl((t, x) -> t+x[1]^2+2x[2], autonomous=false, variable=false)
+julia> u = FeedbackControl((t, x, v) -> t+x[1]^2+2x[2]+v[3], autonomous=false, variable=true)
+```
+
+!!! warning
+
+    When the state is of dimension 1, consider `x` as a scalar.
+
+## Call
+
+The call returns the evaluation of the `FeedbackControl` for given values.
+
+## *Examples*
+
+```@example
+julia> u = FeedbackControl(x -> x[1]^2+2x[2], autonomous=true, variable=false)
+julia> u([1, 0])
+1
+julia> t = 1
+julia> v = Real[]
+julia> u(t, [1, 0])
+MethodError
+julia> u([1, 0], v)
+MethodError
+julia> u(t, [1, 0], v)
+1
+julia> u = FeedbackControl((x, v) -> x[1]^2+2x[2]+v[3], autonomous=true, variable=true)
+julia> u([1, 0], [1, 2, 3])
+4
+julia> u(t, [1, 0], [1, 2, 3])
+4
+julia> u = FeedbackControl((t, x) -> t+x[1]^2+2x[2], autonomous=false, variable=false)
+julia> u(1, [1, 0])
+2
+julia> u(1, [1, 0], v)
+2
+julia> u = FeedbackControl((t, x, v) -> t+x[1]^2+2x[2]+v[3], autonomous=false, variable=true)
+julia> u(1, [1, 0], [1, 2, 3])
+5
+```
+
 """
 struct FeedbackControl{time_dependence, variable_dependence}
     f::Function
@@ -443,6 +933,70 @@ $(TYPEDFIELDS)
 
 Similar to `Hamiltonian` in the usage, but the dimension of the output of the function `f` is arbitrary.
 
+The default values for `time_dependence` and `variable_dependence` are `Autonomous` and `Fixed` respectively.
+
+## Constructor
+
+The constructor ```ControlLaw``` returns a ```ControlLaw``` of a function.
+The function must take 2 to 4 arguments, `(x, p)` to `(t, x, p, v)`, if the function is variable or non autonomous, it must be specified. 
+Dependencies are specified either with :
+    - booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
+    - `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
+
+## *Examples*
+
+```@example
+julia> ControlLaw((x, p) -> x[1]^2+2p[2], Int64)
+IncorrectArgument
+julia> ControlLaw((x, p) -> x[1]^2+2p[2], Int64)
+IncorrectArgument
+julia> u = ControlLaw((x, p) -> x[1]^2+2p[2], Autonomous, Fixed)
+julia> u = ControlLaw((x, p, v) -> x[1]^2+2p[2]+v[3], Autonomous, NonFixed)
+julia> u = ControlLaw((t, x, p) -> t+x[1]^2+2p[2], NonAutonomous, Fixed)
+julia> u = ControlLaw((t, x, p, v) -> t+x[1]^2+2p[2]+v[3], NonAutonomous, NonFixed)
+julia> u = ControlLaw((x, p) -> x[1]^2+2p[2], autonomous=true, variable=false)
+julia> u = ControlLaw((x, p, v) -> x[1]^2+2p[2]+v[3], autonomous=true, variable=true)
+julia> u = ControlLaw((t, x, p) -> t+x[1]^2+2p[2], autonomous=false, variable=false)
+julia> u = ControlLaw((t, x, p, v) -> t+x[1]^2+2p[2]+v[3], autonomous=false, variable=true)
+```
+
+!!! warning
+
+    When the state and costate are of dimension 1, consider `x` and `p` as scalars.
+
+## Call
+
+The call returns the evaluation of the `ControlLaw` for given values.
+
+## *Examples*
+
+```@example
+julia> u = ControlLaw((x, p) -> x[1]^2+2p[2], autonomous=true, variable=false)
+julia> u([1, 0], [0, 1])
+3
+julia> t = 1
+julia> v = Real[]
+julia> u(t, [1, 0], [0, 1])
+MethodError
+julia> u([1, 0], [0, 1], v)
+MethodError
+julia> u(t, [1, 0], [0, 1], v)
+3
+julia> u = ControlLaw((x, p, v) -> x[1]^2+2p[2]+v[3], autonomous=true, variable=true)
+julia> u([1, 0], [0, 1], [1, 2, 3])
+6
+julia> u(t, [1, 0], [0, 1], [1, 2, 3])
+6
+julia> u = ControlLaw((t, x, p) -> t+x[1]^2+2p[2], autonomous=false, variable=false)
+julia> u(1, [1, 0], [0, 1])
+4
+julia> u(1, [1, 0], [0, 1], v)
+4
+julia> u = ControlLaw((t, x, p, v) -> t+x[1]^2+2p[2]+v[3], autonomous=false, variable=true)
+julia> u(1, [1, 0], [0, 1], [1, 2, 3])
+7
+```
+
 """
 struct ControlLaw{time_dependence, variable_dependence}
     f::Function
@@ -457,6 +1011,70 @@ $(TYPEDEF)
 $(TYPEDFIELDS)
 
 Similar to `ControlLaw` in the usage.
+
+The default values for `time_dependence` and `variable_dependence` are `Autonomous` and `Fixed` respectively.
+
+## Constructor
+
+The constructor ```Multiplier``` returns a ```Multiplier``` of a function.
+The function must take 2 to 4 arguments, `(x, p)` to `(t, x, p, v)`, if the function is variable or non autonomous, it must be specified. 
+Dependencies are specified either with :
+    - booleans, `autonomous` and `variable`, respectively `true` and `false` by default 
+    - `DataType`, `Autonomous`/`NonAutonomous` and `NonFixed`/`Fixed`, respectively `Autonomous` and `Fixed` by default.
+
+## *Examples*
+
+```@example
+julia> Multiplier((x, p) -> x[1]^2+2p[2], Int64)
+IncorrectArgument
+julia> Multiplier((x, p) -> x[1]^2+2p[2], Int64)
+IncorrectArgument
+julia> μ = Multiplier((x, p) -> x[1]^2+2p[2], Autonomous, Fixed)
+julia> μ = Multiplier((x, p, v) -> x[1]^2+2p[2]+v[3], Autonomous, NonFixed)
+julia> μ = Multiplier((t, x, p) -> t+x[1]^2+2p[2], NonAutonomous, Fixed)
+julia> μ = Multiplier((t, x, p, v) -> t+x[1]^2+2p[2]+v[3], NonAutonomous, NonFixed)
+julia> μ = Multiplier((x, p) -> x[1]^2+2p[2], autonomous=true, variable=false)
+julia> μ = Multiplier((x, p, v) -> x[1]^2+2p[2]+v[3], autonomous=true, variable=true)
+julia> μ = Multiplier((t, x, p) -> t+x[1]^2+2p[2], autonomous=false, variable=false)
+julia> μ = Multiplier((t, x, p, v) -> t+x[1]^2+2p[2]+v[3], autonomous=false, variable=true)
+```
+
+!!! warning
+
+    When the state and costate are of dimension 1, consider `x` and `p` as scalars.
+
+## Call
+
+The call returns the evaluation of the `Multiplier` for given values.
+
+## *Examples*
+
+```@example
+julia> μ = Multiplier((x, p) -> x[1]^2+2p[2], autonomous=true, variable=false)
+julia> μ([1, 0], [0, 1])
+3
+julia> t = 1
+julia> v = Real[]
+julia> μ(t, [1, 0], [0, 1])
+MethodError
+julia> μ([1, 0], [0, 1], v)
+MethodError
+julia> μ(t, [1, 0], [0, 1], v)
+3
+julia> μ = Multiplier((x, p, v) -> x[1]^2+2p[2]+v[3], autonomous=true, variable=true)
+julia> μ([1, 0], [0, 1], [1, 2, 3])
+6
+julia> μ(t, [1, 0], [0, 1], [1, 2, 3])
+6
+julia> μ = Multiplier((t, x, p) -> t+x[1]^2+2p[2], autonomous=false, variable=false)
+julia> μ(1, [1, 0], [0, 1])
+4
+julia> μ(1, [1, 0], [0, 1], v)
+4
+julia> μ = Multiplier((t, x, p, v) -> t+x[1]^2+2p[2]+v[3], autonomous=false, variable=true)
+julia> μ(1, [1, 0], [0, 1], [1, 2, 3])
+7
+```
 
 """
 struct Multiplier{time_dependence, variable_dependence}

--- a/test/test_default.jl
+++ b/test/test_default.jl
@@ -8,6 +8,14 @@ function test_default()
         @test CTBase.__ocp_time_dependence() == Autonomous
     end
 
+    @testset "Default value of the variable dependence of the functions" begin
+        @test CTBase.__fun_variable_dependence() == Fixed
+    end
+
+    @testset "Default value of the variable dependence of the Optimal Control Problem" begin
+        @test CTBase.__ocp_variable_dependence() == Fixed
+    end
+
     @testset "Default value of the state names of the Optimal Control Problem" begin
         @test CTBase.__state_name() == "x"
         @test CTBase.__state_components_names(2,CTBase.__state_name()) == ["x₁", "x₂"]

--- a/test/test_differential_geometry.jl
+++ b/test/test_differential_geometry.jl
@@ -4,7 +4,7 @@ function test_differential_geometry()
 
     @testset "Lifts" begin
 
-        @testset "HamiltonianLift" begin
+        @testset "HamiltonianLift from VectorField" begin
             HL = HamiltonianLift(VectorField(x -> [x[1]^2,x[2]^2], autonomous=true, variable=false))
             @test HL([1, 0], [0, 1]) == 0
             @test HL(1, [1, 0], [0, 1], 1) == 0
@@ -15,6 +15,31 @@ function test_differential_geometry()
             @test HL(1, [1, 0], [0, 1]) == 0
             @test HL(1, [1, 0], [0, 1], 1) == 0
             HL = HamiltonianLift(VectorField((t, x, v) -> [t+x[1]^2,x[2]^2+v], autonomous=false, variable=true))
+            @test HL(1, [1, 0], [0, 1], 1) == 1
+        end
+
+        @testset "HamiltonianLift from Function" begin
+            HL = HamiltonianLift(x -> [x[1]^2,x[2]^2], autonomous=true, variable=false)
+            @test HL([1, 0], [0, 1]) == 0
+            @test HL(1, [1, 0], [0, 1], 1) == 0
+            HL = HamiltonianLift((x, v) -> [x[1]^2,x[2]^2+v], autonomous=true, variable=true)
+            @test HL([1, 0], [0, 1], 1) == 1
+            @test HL(1, [1, 0], [0, 1], 1) == 1
+            HL = HamiltonianLift((t, x) -> [t+x[1]^2,x[2]^2], autonomous=false, variable=false)
+            @test HL(1, [1, 0], [0, 1]) == 0
+            @test HL(1, [1, 0], [0, 1], 1) == 0
+            HL = HamiltonianLift((t, x, v) -> [t+x[1]^2,x[2]^2+v], autonomous=false, variable=true)
+            @test HL(1, [1, 0], [0, 1], 1) == 1
+            HL = HamiltonianLift(x -> [x[1]^2,x[2]^2], Autonomous, Fixed)
+            @test HL([1, 0], [0, 1]) == 0
+            @test HL(1, [1, 0], [0, 1], 1) == 0
+            HL = HamiltonianLift((x, v) -> [x[1]^2,x[2]^2+v], Autonomous, NonFixed)
+            @test HL([1, 0], [0, 1], 1) == 1
+            @test HL(1, [1, 0], [0, 1], 1) == 1
+            HL = HamiltonianLift((t, x) -> [t+x[1]^2,x[2]^2], NonAutonomous, Fixed)
+            @test HL(1, [1, 0], [0, 1]) == 0
+            @test HL(1, [1, 0], [0, 1], 1) == 0
+            HL = HamiltonianLift((t, x, v) -> [t+x[1]^2,x[2]^2+v], NonAutonomous, NonFixed)
             @test HL(1, [1, 0], [0, 1], 1) == 1
         end
         


### PR DESCRIPTION
Hello, I've written the doc in types.jl as follows : 
![image](https://github.com/control-toolbox/CTBase.jl/assets/123751661/17447c9c-0044-4b34-82ac-a2aee5d9a86b)
I also added some tests for coverage and changed the HamiltonianLift of a VectorField of type Function because it didn't work and was therefore not tested. It's tested now.
Otherwise, the function 
```julia
# ---------------------------------------------------------------------------
# partial derivative wrt time
∂ₜ(f) = (t, args...) -> ctgradient(y -> f(y, args...), t)
```
 is not used, do we keep it or not ? 
(related to #110 )