### PR TITLE
fixed __wrap and __throw

### DIFF
--- a/src/onepass.jl
+++ b/src/onepass.jl
@@ -1,6 +1,5 @@
 # onepass
 # todo:
-# - for all p_... functions, write: code = quote ... end; __wrap(code, p.lnum, p.line)
 # - cannot call solve if problem not fully defined (dynamics not defined...)
 # - doc: explain projections wrt to t0, tf, t; (...x1...x2...)(t) -> ...gensym1...gensym2... (most internal first)
 # - test non autonomous cases
@@ -36,14 +35,14 @@ __init_aliases() = begin
     al
 end
 
-__throw(ex, n, line) = begin
-    quote
-        info = string("\nLine ", $n, ": ", $line)
-        throw(ParsingError(info * "\n" * $ex))
-    end
+__throw(ex, n, line) = quote
+    local info
+    info = string("\nLine ", $n, ": ", $line)
+    throw(ParsingError(info * "\n" * $ex))
 end
 
 __wrap(e, n, line) = quote
+    local ex
     try
         $e
     catch ex


### PR DESCRIPTION
Quotations (= `quote ... end`) that defined local variables need these variables to be explicitly declared as local (`local`):
```julia
julia> foo() = quote
              try 0 + [ 0 ]
              catch a println(a) end
              end
foo (generic function with 1 method)

julia> eval(foo())
MethodError(+, (0, [0]), 0x0000000000007aef)

julia> a
ERROR: UndefVarError: `a` not defined

julia> a = 1
1

julia> eval(foo())
┌ Warning: Assignment to `a` in soft scope is ambiguous because a global variable by the same name exists: `a` will be treated as a new local. Disambiguate by using `local a` to suppress this warning or `global a` to assign to the existing global variable.
└ @ REPL[1]:2
MethodError(+, (0, [0]), 0x0000000000007aef)

julia> a
1

julia> foo() = quote local a
              try 0 + [ 0 ]
              catch a println(a) end
              end
foo (generic function with 1 method)

julia> eval(foo())
MethodError(+, (0, [0]), 0x0000000000007af0)

julia> a
1
````

NB. Also note the semantics of `try ... catch` depending on whether the variable exists or not in the global scope:

```julia
julia> b
ERROR: UndefVarError: `b` not defined

julia> try 0 + [ 0 ]
       catch b
       println(b)
       end
MethodError(+, (0, [0]), 0x0000000000007af0)

julia> b
ERROR: UndefVarError: `b` not defined

julia> b = 1
1

julia> try 0 + [ 0 ]
       catch b
       println(b)
       end
MethodError(+, (0, [0]), 0x0000000000007af0)

julia> b
MethodError(+, (0, [0]), 0x0000000000007af0)
```