### PR TITLE
Start using DifferentiationInterface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,11 @@
 name = "CTBase"
 uuid = "54762871-cc72-4466-b8e8-f6c8b58076cd"
 authors = ["Olivier Cots <olivier.cots@enseeiht.fr>"]
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
@@ -21,6 +22,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 DataStructures = "0.18"
+DifferentiationInterface = "0.5"
 DocStringExtensions = "0.9"
 ForwardDiff = "0.10"
 Interpolations = "0.15"

--- a/src/CTBase.jl
+++ b/src/CTBase.jl
@@ -14,7 +14,8 @@ module CTBase
 # using
 import Base
 using DocStringExtensions
-using ForwardDiff: jacobian, gradient, ForwardDiff # automatic differentiation
+using DifferentiationInterface: AutoForwardDiff, derivative, gradient, jacobian, prepare_derivative, prepare_gradient, prepare_jacobian
+using ForwardDiff: ForwardDiff # automatic differentiation
 using Interpolations: linear_interpolation, Line, Interpolations # for default interpolation
 using MLStyle # pattern matching
 using Parameters # @with_kw: to have default values in struct

--- a/src/CTBase.jl
+++ b/src/CTBase.jl
@@ -15,7 +15,7 @@ module CTBase
 import Base
 using DocStringExtensions
 using DifferentiationInterface: AutoForwardDiff, derivative, gradient, jacobian, prepare_derivative, prepare_gradient, prepare_jacobian
-using ForwardDiff: ForwardDiff # automatic differentiation
+import ForwardDiff
 using Interpolations: linear_interpolation, Line, Interpolations # for default interpolation
 using MLStyle # pattern matching
 using Parameters # @with_kw: to have default values in struct
@@ -94,6 +94,8 @@ const DState     = ctVector
 Type alias for a tangent vector to the costate space.
 """
 const DCostate   = ctVector
+
+__auto() = AutoForwardDiff()
 
 #
 include("exception.jl")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -74,7 +74,7 @@ $(TYPEDSIGNATURES)
 Return the gradient of `f` at `x`.
 """
 function ctgradient(f::Function, x::ctNumber)
-    backend = AutoForwardDiff()
+    backend = __auto()
     extras = prepare_derivative(f, backend, x)
     return derivative(f, backend, x, extras)
 end
@@ -85,7 +85,7 @@ $(TYPEDSIGNATURES)
 Return the gradient of `f` at `x`.
 """
 function ctgradient(f::Function, x)
-    backend = AutoForwardDiff()
+    backend = __auto()
     extras = prepare_gradient(f, backend, x)
     return gradient(f, backend, x, extras)
 end
@@ -104,7 +104,7 @@ Return the Jacobian of `f` at `x`.
 """
 function ctjacobian(f::Function, x::ctNumber)
     f_number_to_number = only ∘ f ∘ only
-    backend = AutoForwardDiff()
+    backend = __auto()
     extras = prepare_derivative(f_number_to_number, backend, x)
     der = derivative(f_number_to_number, backend, x, extras)
     return [der;;]
@@ -116,7 +116,7 @@ $(TYPEDSIGNATURES)
 Return the Jacobian of `f` at `x`.
 """
 function ctjacobian(f::Function, x)
-    backend = AutoForwardDiff()
+    backend = __auto()
     extras = prepare_jacobian(f, backend, x)
     return jacobian(f, backend, x, extras)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -74,7 +74,9 @@ $(TYPEDSIGNATURES)
 Return the gradient of `f` at `x`.
 """
 function ctgradient(f::Function, x::ctNumber)
-    return ForwardDiff.derivative(x -> f(x), x)
+    backend = AutoForwardDiff()
+    extras = prepare_derivative(f, backend, x)
+    return derivative(f, backend, x, extras)
 end
 
 """
@@ -83,7 +85,9 @@ $(TYPEDSIGNATURES)
 Return the gradient of `f` at `x`.
 """
 function ctgradient(f::Function, x)
-    return ForwardDiff.gradient(f, x)
+    backend = AutoForwardDiff()
+    extras = prepare_gradient(f, backend, x)
+    return gradient(f, backend, x, extras)
 end
 
 """
@@ -98,8 +102,12 @@ $(TYPEDSIGNATURES)
 
 Return the Jacobian of `f` at `x`.
 """
-function ctjacobian(f::Function, x::ctNumber) 
-    return ForwardDiff.jacobian(x -> f(x[1]), [x])
+function ctjacobian(f::Function, x::ctNumber)
+    f_number_to_number = only ∘ f ∘ only
+    backend = AutoForwardDiff()
+    extras = prepare_derivative(f_number_to_number, backend, x)
+    der = derivative(f_number_to_number, backend, x, extras)
+    return [der;;]
 end
 
 """
@@ -107,7 +115,11 @@ $(TYPEDSIGNATURES)
 
 Return the Jacobian of `f` at `x`.
 """
-ctjacobian(f::Function, x) = ForwardDiff.jacobian(f, x)
+function ctjacobian(f::Function, x)
+    backend = AutoForwardDiff()
+    extras = prepare_jacobian(f, backend, x)
+    return jacobian(f, backend, x, extras)
+end
 
 """
 $(TYPEDSIGNATURES)


### PR DESCRIPTION
This PR is the beginning of a solution for #25. It shows how you can use DifferentiationInterface to compute derivatives in a backend-agnostic fashion.
It seems mergeable to me, but here are some more things you can do to increase performance:

- Figure out if you need several backend objects or just one. For instance, derivatives are more efficient with a forward-mode backend, while gradients are usually more efficient with a reverse-mode backend.
- Adjust the public API so that you can pass the `backend` object(s) from the user-facing functions all the way down to the utility functions.
- Decide if you can reuse the `extras` that arise from the [preparation step](https://gdalle.github.io/DifferentiationInterface.jl/DifferentiationInterface/stable/operators/#Operators-Preparation), and if so, adjust the code to initialize them once and then pass them around.

Ping @ocots @jbcaillau 