### PR TITLE
const ref for (global) module variable

### DIFF
--- a/src/default.jl
+++ b/src/default.jl
@@ -1,8 +1,8 @@
 #
-__default_AD_backend = AutoForwardDiff()
+const __default_AD_backend = Ref(AutoForwardDiff())
 
 function set_AD_backend(AD) 
-    global __default_AD_backend = AD
+    global __default_AD_backend[] = AD
     nothing
 end
 
@@ -13,7 +13,7 @@ Used to set the default value of Automatic Differentiation backend.
 
 The default value is `AutoForwardDiff()`, that is the `ForwardDiff` package is used by default.
 """
-__get_AD_backend() = __default_AD_backend # default AD backend
+__get_AD_backend() = __default_AD_backend[] # default AD backend
 
 """
 $(TYPEDSIGNATURES)


### PR DESCRIPTION
Changed the module var. for the AD backend to constant reference, following [this](https://github.com/JuliaDiff/BlueStyle?tab=readme-ov-file#global-variables) 