### PR TITLE
replaced OptimalControlInit with updated _OptimalControlInit

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CTBase"
 uuid = "54762871-cc72-4466-b8e8-f6c8b58076cd"
 authors = ["Olivier Cots <olivier.cots@enseeiht.fr>", "Jean-Baptiste Caillau <caillau@unice.fr>"]
-version = "0.11.0"
+version = "0.10.3"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CTBase"
 uuid = "54762871-cc72-4466-b8e8-f6c8b58076cd"
 authors = ["Olivier Cots <olivier.cots@enseeiht.fr>", "Jean-Baptiste Caillau <caillau@unice.fr>"]
-version = "0.10.2"
+version = "0.11.0"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/CTBase.jl
+++ b/src/CTBase.jl
@@ -250,7 +250,7 @@ export variable!, time!, constraint!, dynamics!, objective!, state!, control!, r
 export is_autonomous, is_fixed, is_time_independent, is_time_dependent, is_min, is_max, is_variable_dependent, is_variable_independent
 export nlp_constraints!, constraints_labels
 export has_free_final_time, has_free_initial_time, has_lagrange_cost, has_mayer_cost
-export dim_control_constraints, dim_state_constraints, dim_mixed_constraints, dim_path_constraints, dim_boundary_constraints, dim_variable_constraints, dim_control_range, dim_state_range, dim_variable_range, dim_control_box, dim_state_box, dim_variable_box
+export dim_control_constraints, dim_state_constraints, dim_mixed_constraints, dim_path_constraints, dim_boundary_constraints, dim_variable_constraints, dim_control_range, dim_state_range, dim_variable_range
 
 # solution
 export OptimalControlSolution

--- a/src/CTBase.jl
+++ b/src/CTBase.jl
@@ -256,7 +256,7 @@ export dim_control_constraints, dim_state_constraints, dim_mixed_constraints, di
 export OptimalControlSolution
 
 # initialization
-export _OptimalControlInit
+export OptimalControlInit
 
 # utils
 export ctgradient, ctjacobian, ctinterpolate, ctindices, ctupperscripts

--- a/src/CTBase.jl
+++ b/src/CTBase.jl
@@ -256,7 +256,7 @@ export dim_control_constraints, dim_state_constraints, dim_mixed_constraints, di
 export OptimalControlSolution
 
 # initialization
-export OptimalControlInit
+export _OptimalControlInit
 
 # utils
 export ctgradient, ctjacobian, ctinterpolate, ctindices, ctupperscripts

--- a/src/init.jl
+++ b/src/init.jl
@@ -1,6 +1,234 @@
 """
 $(TYPEDSIGNATURES)
 
+Check if actual dimension is equal to target dimension, error otherwise
+"""
+function checkDim(actual_dim, target_dim)
+    if !isnothing(target_dim) && actual_dim != target_dim
+        error("Init dimension mismatch: got ",actual_dim," instead of ",target_dim )
+    end
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return true if argument is a vector of vectors
+"""
+function isaVectVect(data)
+    return (data isa Vector) && (data[1] isa ctVector)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Convert matrix to vector of vectors (could be expanded)
+"""
+function formatData(data)
+    if data isa Matrix
+        return matrix2vec(data,1)
+    else
+        return data
+    end
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Convert matrix time-grid to vector
+"""
+function formatTimeGrid(time)
+    if isnothing(time)
+        return nothing
+    elseif time isa ctVector
+        return time
+    else
+        return vec(time)
+    end
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Build functional initialization: default case
+"""
+function buildFunctionalInit(data::Nothing, time, dim)
+    # fallback to method-dependent default initialization
+    return t-> nothing
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Build functional initialization: function case
+"""
+function buildFunctionalInit(data::Function, time, dim)
+    # functional initialization
+    checkDim(length(data(0)),dim)
+    return t -> data(t)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Build functional initialization: constant / 1D interpolation
+"""
+function buildFunctionalInit(data::ctVector, time, dim)
+    if !isnothing(time) && (length(data) == length(time))
+        # interpolation vs time, dim 1 case
+        itp = ctinterpolate(time, data)
+        return t -> itp(t)
+    else
+        # constant initialization
+        checkDim(length(data), dim)
+        return t -> data
+    end
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Build functional initialization: general interpolation case
+"""
+function buildFunctionalInit(data, time, dim)
+    if isaVectVect(data)
+        # interpolation vs time, general case
+        itp = ctinterpolate(time, data)
+        checkDim(length(itp(0)), dim)
+        return t -> itp(t)
+    else
+        error("Unrecognized initialization argument: ",typeof(data))
+    end
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Build vector initialization: default / vector case
+"""
+function buildVectorInit(data, dim)
+    if isnothing(data)
+        return data
+    else
+        checkDim(length(data),dim)
+        return data
+    end
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Initial guess for OCP, contains
+- functions of time for the state and control variables
+- vector for optimization variables
+Initialization data for each field can be left to default or: 
+- vector for optimization variables
+- constant / vector / function for state and control  
+- existing solution ('warm start') for all fields
+
+# Constructors:
+
+- `_OptimalControlInit()`: default initialization
+- `_OptimalControlInit(state, control, variable, time)`: constant vector, function handles and / or matrices / vectors interpolated along given time grid
+- `_OptimalControlInit(sol)`: from existing solution
+
+# Examples
+
+```julia-repl
+julia> init = _OptimalControlInit()
+julia> init = _OptimalControlInit(state=[0.1, 0.2], control=0.3)
+julia> init = _OptimalControlInit(state=[0.1, 0.2], control=0.3, variable=0.5)
+julia> init = _OptimalControlInit(state=[0.1, 0.2], controlt=t->sin(t), variable=0.5)
+julia> init = _OptimalControlInit(state=[[0, 0], [1, 2], [5, -1]], time=[0, .3, 1.], controlt=t->sin(t))
+julia> init = _OptimalControlInit(sol)
+```
+
+"""
+mutable struct _OptimalControlInit
+   
+    state_init::Function
+    control_init::Function
+    variable_init::Union{Nothing, ctVector}
+    #costate_init::Function
+    #multipliers_init::Union{Nothing, ctVector}
+
+    """
+    $(TYPEDSIGNATURES)
+
+    _OptimalControlInit base constructor with separate explicit arguments
+    """
+    function _OptimalControlInit(; state=nothing, control=nothing, variable=nothing, time=nothing, state_dim=nothing, control_dim=nothing, variable_dim=nothing)
+        
+        init = new()
+    
+        # some matrix / vector conversions
+        time = formatTimeGrid(time)
+        state = formatData(state)
+        control = formatData(control)
+        
+        # set initialization for x, u, v
+        init.state_init = buildFunctionalInit(state, time, state_dim)
+        init.control_init = buildFunctionalInit(control, time, control_dim)
+        init.variable_init = buildVectorInit(variable, variable_dim)
+
+        return init
+
+    end
+
+    """
+    $(TYPEDSIGNATURES)
+
+    _OptimalControlInit constructor with arguments grouped as named tuple or dict
+    """
+    function _OptimalControlInit(init_data; state_dim=nothing, control_dim=nothing, variable_dim=nothing)
+
+        # trivial case: default init
+        x_init = nothing
+        u_init = nothing
+        v_init = nothing
+        t_init = nothing
+        x_dim = nothing
+        u_dim = nothing
+        v_dim = nothing
+
+        # parse arguments
+        if !isnothing(init_data)
+            for key in keys(init_data)
+                if key == :state
+                    x_init = init_data[:state]
+                elseif key == :control
+                    u_init = init_data[:control]
+                elseif key == :variable
+                    v_init = init_data[:variable]
+                elseif key == :time
+                    t_init = init_data[:time]
+                else
+                    error("Unknown key in initialization data (allowed: state, control, variable, time, state_dim, control_dim, variable_dim): ", key)
+                end
+            end
+        end
+
+        # call base constructor
+        return _OptimalControlInit(state=x_init, control=u_init, variable=v_init, time=t_init, state_dim=state_dim, control_dim=control_dim, variable_dim=variable_dim)
+    
+    end
+
+    """
+    $(TYPEDSIGNATURES)
+
+    _OptimalControlInit constructor with solution as argument (warm start)
+    """
+    function _OptimalControlInit(sol::OptimalControlSolution; unused_kwargs...)
+        return _OptimalControlInit(state=sol.state, control=sol.control, variable=sol.variable, state_dim=sol.state_dimension, control_dim=sol.control_dimension, variable_dim=sol.variable_dimension)
+    end
+
+end
+
+
+
+#= OLD VERSION
+"""
+$(TYPEDSIGNATURES)
+
 Initialization of the OCP solution that can be used when solving the discretized problem DOCP.
 
 # Constructors:
@@ -73,3 +301,4 @@ mutable struct OptimalControlInit
     end
 
 end
+=#

--- a/src/model.jl
+++ b/src/model.jl
@@ -1082,7 +1082,6 @@ Return the dimension of range constraints on state (`nothing` if not knonw).
 Information is updated after `nlp_constraints!` is called.
 """
 dim_state_range(ocp::OptimalControlModel) = ocp.dim_state_range 
-dim_state_box = dim_state_range # alias, CTDirect.jl compatibility
 
 """
 $(TYPEDSIGNATURES)
@@ -1091,7 +1090,6 @@ Return the dimension of range constraints on control (`nothing` if not knonw).
 Information is updated after `nlp_constraints!` is called.
 """
 dim_control_range(ocp::OptimalControlModel) = ocp.dim_control_range 
-dim_control_box = dim_control_range # alias, CTDirect.jl compatibility
 
 """
 $(TYPEDSIGNATURES)
@@ -1100,4 +1098,3 @@ Return the dimension of range constraints on variable (`nothing` if not knonw).
 Information is updated after `nlp_constraints!` is called.
 """
 dim_variable_range(ocp::OptimalControlModel) = ocp.dim_variable_range
-dim_variable_box = dim_variable_range # alias, CTDirect.jl compatibility


### PR DESCRIPTION
Ok, here we are, you can review the changes.

We should be able to test this one with pre-release 0.9.0 of CTDirect that corresponds to the v0.9.0 branch.

- [x] check tests from CTDirect using local dev'd versions for both packages
- [x] check tests from OptimalControl using local dev'd versions for both packages