### PR TITLE
add aqua and remove a function: api change

### DIFF
--- a/.github/workflows/Breakage.yml
+++ b/.github/workflows/Breakage.yml
@@ -1,0 +1,129 @@
+# Ref: https://securitylab.github.com/research/github-actions-preventing-pwn-requests
+name: Breakage
+
+# read-only repo token
+# no access to secrets
+on:
+  pull_request:
+
+jobs:
+  break:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pkg: [
+          "control-toolbox/CTDirect.jl",
+          "control-toolbox/CTFlows.jl",
+          "control-toolbox/OptimalControl.jl",
+        ]
+        pkgversion: [latest, stable]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Install Julia
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: 1
+          arch: x64
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+
+      # Breakage test
+      - name: 'Breakage of ${{ matrix.pkg }}, ${{ matrix.pkgversion }} version'
+        env:
+          URL: ${{ matrix.pkg }}
+          VERSION: ${{ matrix.pkgversion }}
+        run: |
+          set -v
+          mkdir -p ./pr
+          echo "${{ github.event.number }}" > ./pr/NR
+          git clone https://github.com/$URL
+          export PKG=$(echo $URL | cut -f2 -d/)
+          cd $PKG
+          if [ $VERSION == "stable" ]; then
+            TAG=$(git tag -l "v*" --sort=-creatordate | head -n1)
+            if [ -z "$TAG" ]; then
+              TAG="no_tag"
+            else
+              git checkout $TAG
+            fi
+          else
+            TAG=$VERSION
+          fi
+          export TAG
+          julia -e 'using Pkg;
+            PKG, TAG, VERSION = ENV["PKG"], ENV["TAG"], ENV["VERSION"]
+            joburl = joinpath(ENV["GITHUB_SERVER_URL"], ENV["GITHUB_REPOSITORY"], "actions/runs", ENV["GITHUB_RUN_ID"])
+            open("../pr/$PKG-$VERSION", "w") do io
+              try
+                TAG == "no_tag" && error("Not tag for $VERSION")
+                pkg"activate .";
+                pkg"instantiate";
+                pkg"dev ../";
+                pkg"build";
+                pkg"test";
+
+                print(io, "[![](https://img.shields.io/badge/$TAG-Pass-green)]($joburl)");
+              catch e
+                @error e;
+                print(io, "[![](https://img.shields.io/badge/$TAG-Fail-red)]($joburl)");
+              end;
+            end'
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/
+
+  upload:
+    needs: break
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: pr
+          path: pr/
+
+      - run: ls
+      - run: |
+          cd pr
+          echo "| Package name | latest | stable |" > MSG
+          echo "|--|--|--|" >> MSG
+          count=0
+          for file in *
+          do
+            [ "$file" == "NR" ] && continue
+            [ "$file" == "MSG" ] && continue
+            if [ $count == "0" ]; then
+              name=$(echo $file | cut -f1 -d-)
+              echo -n "| $name | "
+            else
+              echo -n "| "
+            fi
+            cat $file
+            if [ $count == "0" ]; then
+              echo -n " "
+              count=1
+            else
+              echo " |"
+              count=0
+            fi
+          done >> MSG
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CTBase"
 uuid = "54762871-cc72-4466-b8e8-f6c8b58076cd"
-authors = ["Olivier Cots <olivier.cots@enseeiht.fr>", "Jean-Baptiste Caillau <caillau@univ-cotedazur.fr>"]
-version = "0.12.3"
+authors = ["Olivier Cots <olivier.cots@irit.fr>", "Jean-Baptiste Caillau <caillau@univ-cotedazur.fr>"]
+version = "0.13.0"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
@@ -34,6 +34,7 @@ Interpolations = "0.15"
 MLStyle = "0.4"
 MacroTools = "0.5"
 Parameters = "0.12"
+Plots = "1.40"
 PrettyTables = "2.2"
 Printf = "1.8"
 Reexport = "1.2"

--- a/src/description.jl
+++ b/src/description.jl
@@ -132,24 +132,10 @@ Return the difference between the description `x` and the description `y`.
 # Example
 
 ```@example
-julia> (:a, :b) \\ (:a,)
-(:b,)
-```
-"""
-Base.:(\)(x::Description, y::Description)::Description = Tuple(setdiff(x, y))
-
-"""
-$(TYPEDSIGNATURES)
-
-Return the difference between the description `x` and the description `y`.
-
-# Example
-
-```@example
 julia> remove((:a, :b), (:a,))
 (:b,)
 ```
 """
 function remove(x::Description, y::Description)::Description
-    return x \ y
+    return Tuple(setdiff(x, y))
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,7 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,13 @@
+#
+using Aqua
+using ForwardDiff
+using StaticArrays
+
+#
 using CTBase
-using Test
-using Plots
 using DifferentiationInterface: AutoForwardDiff
+using Plots
+using Test
 
 # functions and types that are not exported
 const vec2vec  = CTBase.vec2vec
@@ -16,6 +22,7 @@ include("utils.jl")
 #
 @testset verbose = true showtiming = true "Base" begin
     for name ∈ (
+        :aqua,
         :callback,
         :ctparser_utils,
         :default,

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -1,0 +1,22 @@
+function test_aqua()
+
+@testset "Aqua.jl" begin
+  Aqua.test_all(
+    CTBase;
+    ambiguities=(
+        exclude=[
+            ForwardDiff.:(==),
+            ForwardDiff.:(^),
+            ForwardDiff.convert,
+            ForwardDiff.Dual,
+            ForwardDiff.log,
+            ForwardDiff.promote_rule,
+            StaticArrays.getindex
+        ], broken=true),
+    #stale_deps=(ignore=[:SomePackage],),
+    deps_compat=(ignore=[:LinearAlgebra, :Unicode],),
+    piracies=true,
+  )
+end
+
+end

--- a/test/test_description.jl
+++ b/test/test_description.jl
@@ -30,9 +30,8 @@ algorithmes = add(algorithmes, (:descent, :gradient, :fixedstep))
 # diff
 x=(:a,:b,:c)
 y=(:b,)
-@test x\y == (:a, :c)
 @test remove(x, y) == (:a, :c)
-@test typeof(x\y) <: Description
+@test typeof(remove(x, y)) <: Description
 
 # inclusion and different sizes
 algorithmes = ()


### PR DESCRIPTION
I have removed the function 

```julia
Base.:(\)(x::Description, y::Description)::Description = Tuple(setdiff(x, y))
```

since it is a type piracy. It is replaced by `remove(x, y)`.

Not very important but it changes the api and I use it in `OptimalControl`. So I have modified the Project.toml to go the release `0.13`.