### PR TITLE
No unicode update

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CTBase"
 uuid = "54762871-cc72-4466-b8e8-f6c8b58076cd"
 authors = ["Olivier Cots <olivier.cots@enseeiht.fr>", "Jean-Baptiste Caillau <caillau@univ-cotedazur.fr>"]
-version = "0.12.4"
+version = "0.12.5"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/onepass.jl
+++ b/src/onepass.jl
@@ -175,13 +175,14 @@ p_variable!(p, ocp, v, q; components_names=nothing, log=false) = begin
     p.v = v
     vv = QuoteNode(v)
     qq = q isa Integer ? q : 9
-    for i ∈ 1:qq p.aliases[Symbol(v, ctindices(i))] = :( $v[$i] ) end
-    for i ∈ 1:9  p.aliases[Symbol(v, ctupperscripts(i))] = :( $v^$i  ) end
+    for i ∈ 1:qq p.aliases[Symbol(v, ctindices(i))]      = :( $v[$i] ) end # make: v₁, v₂... if the variable is named v
+    for i ∈ 1:qq p.aliases[Symbol(v, i)]                 = :( $v[$i] ) end # make: v1, v2... if the variable is named v
+    for i ∈ 1:9  p.aliases[Symbol(v, ctupperscripts(i))] = :( $v^$i  ) end # make: v¹, v²... if the variable is named v
     if (isnothing(components_names))
         __wrap(:( variable!($ocp, $q, $vv) ), p.lnum, p.line)
     else
         qq==length(components_names.args) || return __throw("the number of variable components must be $qq", p.lnum, p.line)
-        for i ∈ 1:qq p.aliases[components_names.args[i]] = :( $v[$i] ) end
+        for i ∈ 1:qq p.aliases[components_names.args[i]] = :( $v[$i] ) end # aliases from names given by the user
         ss = QuoteNode(string.(components_names.args))
         __wrap(:( variable!($ocp, $q, $vv, $ss) ), p.lnum, p.line) 
     end
@@ -237,14 +238,15 @@ p_state!(p, ocp, x, n; components_names=nothing, log=false) = begin
     p.x = x
     xx = QuoteNode(x)
     nn = n isa Integer ? n : 9
-    for i ∈ 1:nn p.aliases[Symbol(x, ctindices(i))] = :( $x[$i] ) end
-    for i ∈ 1:9  p.aliases[Symbol(x, ctupperscripts(i))] = :( $x^$i  ) end
+    for i ∈ 1:nn p.aliases[Symbol(x, ctindices(i))]      = :( $x[$i] ) end # make: x₁, x₂... if the state is named x
+    for i ∈ 1:nn p.aliases[Symbol(x, i)]                 = :( $x[$i] ) end # make: x1, x2... if the state is named x
+    for i ∈ 1:9  p.aliases[Symbol(x, ctupperscripts(i))] = :( $x^$i  ) end # make: x¹, x²... if the state is named x
     p.aliases[Symbol(Unicode.normalize(string(x,"̇")))] = :( ∂($x) )
     if (isnothing(components_names))
         __wrap(:( state!($ocp, $n, $xx) ), p.lnum, p.line)
     else
         nn==length(components_names.args) || return __throw("the number of state components must be $nn", p.lnum, p.line)
-        for i ∈ 1:nn p.aliases[components_names.args[i]] = :( $x[$i] ) end
+        for i ∈ 1:nn p.aliases[components_names.args[i]] = :( $x[$i] ) end # aliases from names given by the user
         ss = QuoteNode(string.(components_names.args))
         __wrap(:( state!($ocp, $n, $xx, $ss) ), p.lnum, p.line)
     end
@@ -256,13 +258,14 @@ p_control!(p, ocp, u, m; components_names=nothing, log=false) = begin
     p.u = u
     uu = QuoteNode(u)
     mm =  m isa Integer ? m : 9
-    for i ∈ 1:mm p.aliases[Symbol(u, ctindices(i))] = :( $u[$i] ) end
-    for i ∈ 1:9  p.aliases[Symbol(u, ctupperscripts(i))] = :( $u^$i  ) end
+    for i ∈ 1:mm p.aliases[Symbol(u, ctindices(i))]      = :( $u[$i] ) end # make: u₁, u₂... if the control is named u
+    for i ∈ 1:mm p.aliases[Symbol(u, i)]                 = :( $u[$i] ) end # make: u1, u2... if the control is named u
+    for i ∈ 1:9  p.aliases[Symbol(u, ctupperscripts(i))] = :( $u^$i  ) end # make: u¹, u²... if the control is named u
     if (isnothing(components_names))
         __wrap(:( control!($ocp, $m, $uu) ), p.lnum, p.line)
     else
         mm==length(components_names.args) || return __throw("the number of control components must be $mm", p.lnum, p.line)
-        for i ∈ 1:mm p.aliases[components_names.args[i]] = :( $u[$i] ) end
+        for i ∈ 1:mm p.aliases[components_names.args[i]] = :( $u[$i] ) end # aliases from names given by the user
         ss = QuoteNode(string.(components_names.args))
         __wrap(:( control!($ocp, $m, $uu, $ss) ), p.lnum, p.line)
     end

--- a/src/onepass.jl
+++ b/src/onepass.jl
@@ -38,6 +38,7 @@ __init_aliases(;max_dim=20) = begin
     al[:derivative] = :∂
     al[:integral] = :∫
     al[:( => )] = :→
+    al[:in] = :∈
     al
 end
 

--- a/test/test_onepass.jl
+++ b/test/test_onepass.jl
@@ -53,6 +53,15 @@ end
     println("aliases testset...")
 
     @def o begin
+        x = (y, z) in R², state
+        u = (uu1, uu2, uu3) in R³, control
+        v = (vv1, vv2) in R², variable
+    end
+    @test o.state_components_names == [ "y", "z" ]
+    @test o.control_components_names == [ "uu1", "uu2", "uu3" ]
+    @test o.variable_components_names == [ "vv1", "vv2" ]
+
+    @def o begin
         x = (y, z) ∈ R², state
         u = (uu1, uu2, uu3) ∈ R³, control
         v = (vv1, vv2) ∈ R², variable
@@ -2401,13 +2410,13 @@ end
     t0 = 0
     tf = 1
     @def o begin
-        t ∈ [ t0, tf ], time
-        x ∈ R^2, state
-        u ∈ R, control
+        t in [ t0, tf ], time
+        x in R^2, state
+        u in R, control
         x(t0) == [ -1, 0 ], (1)
         x(tf) == [  0, 0 ]
         derivative(x)(t) == A * x(t) + B * u(t)
-        integral( 0.5u(t)^2 ) → min
+        integral( 0.5u(t)^2 ) => min
     end
     x = [ 1, 2 ]
     x0 = 2 * x
@@ -2423,18 +2432,18 @@ end
     @test o.criterion == :min
 
     @def o begin
-        z ∈ R, variable
-        t ∈ [ 0, 1 ], time
-        x ∈ R², state
-        u ∈ R, control
-        r = x₁
-        v = x₂
+        z in R, variable
+        t in [ 0, 1 ], time
+        x in R^2, state
+        u in R, control
+        r = x1
+        v = x2
         0 <= r(0) - z <= 1,            (1)
         0 <= v(1)^2 <= 1,              (2)
         [ 0, 0 ] <= x(0) <= [ 1, 1 ],  (♡)
         z >= 0,                        (3)
-        ẋ(t) == [ v(t), r(t)^2 + z ]
-        ∫( u(t)^2 + z * x₁(t) ) → min
+        derivative(x)(t) == [ v(t), r(t)^2 + z ]
+        integral( u(t)^2 + z * x1(t) ) => min
     end
     x0 = [ 2, 3 ]
     xf = [ 4, 5 ]
@@ -2449,18 +2458,18 @@ end
     @test o.lagrange(x, u, z) == u^2 + z * x[1]
 
     @def o begin
-        z ∈ R, variable
-        t ∈ [ 0, 1 ], time
-        x ∈ R², state
-        u ∈ R, control
-        r = x₁
-        v = x₂
+        z in R, variable
+        t in [ 0, 1 ], time
+        x in R^2, state
+        u in R, control
+        r = x1
+        v = x2
         0 <= r(0) - z <= 1,            (1)
         0 <= v(1)^2 <= 1,              (2)
         [ 0, 0 ] <= x(0) <= [ 1, 1 ],  (♡)
         z >= 0,                        (3)
-        ẋ(t) == [ v(t), r(t)^2 + z ]
-        ∫( u(t)^2 + z * x₁(t) ) => min
+        derivative(x)(t) == [ v(t), r(t)^2 + z ]
+        integral( u(t)^2 + z * x1(t) ) => min
     end
     x0 = [ 2, 3 ]
     xf = [ 4, 5 ]

--- a/test/test_onepass.jl
+++ b/test/test_onepass.jl
@@ -2436,14 +2436,14 @@ end
         t in [ 0, 1 ], time
         x in R^2, state
         u in R, control
-        r = x1
-        v = x2
+        r = x[1]
+        v = x[2]
         0 <= r(0) - z <= 1,            (1)
         0 <= v(1)^2 <= 1,              (2)
         [ 0, 0 ] <= x(0) <= [ 1, 1 ],  (♡)
         z >= 0,                        (3)
         derivative(x)(t) == [ v(t), r(t)^2 + z ]
-        integral( u(t)^2 + z * x1(t) ) => min
+        integral( u(t)^2 + z * x[1](t) ) => min
     end
     x0 = [ 2, 3 ]
     xf = [ 4, 5 ]
@@ -2462,14 +2462,14 @@ end
         t in [ 0, 1 ], time
         x in R^2, state
         u in R, control
-        r = x1
-        v = x2
+        r = x[1]
+        v = x[2]
         0 <= r(0) - z <= 1,            (1)
         0 <= v(1)^2 <= 1,              (2)
         [ 0, 0 ] <= x(0) <= [ 1, 1 ],  (♡)
         z >= 0,                        (3)
         derivative(x)(t) == [ v(t), r(t)^2 + z ]
-        integral( u(t)^2 + z * x1(t) ) => min
+        integral( u(t)^2 + z * x[1](t) ) => min
     end
     x0 = [ 2, 3 ]
     xf = [ 4, 5 ]
@@ -2483,6 +2483,34 @@ end
     @test o.dynamics(x, u, z) == [ x[2], x[1]^2 + z ]
     @test o.lagrange(x, u, z) == u^2 + z * x[1]
      
+    @def o begin
+        z in R^2, variable
+        t in [ 0, 1 ], time
+        x in R^2, state
+        u in R^2, control
+        r = x1
+        v = x2
+        0 <= r(0) - z1 <= 1,            (1)
+        0 <= v(1)^2 <= 1,               (2)
+        [ 0, 0 ] <= x(0) <= [ 1, 1 ],   (♡)
+        z1 >= 0,                        (3)
+        z2 == 1
+        u2(t) == 0
+        derivative(x)(t) == [ v(t), r(t)^2 + z1 ]
+        integral( u1(t)^2 + z1 * x1(t) ) => min
+    end
+    x0 = [ 2, 3 ]
+    xf = [ 4, 5 ]
+    x = [ 1, 2 ]
+    u = [3, 0]
+    z = [4, 1]
+    @test constraint(o, :eq1)(x0, xf, z) == x0[1] - z[1]
+    @test constraint(o, :eq2)(x0, xf, z) == xf[2]^2
+    @test constraint(o, Symbol("♡"))(x0, xf, z) == x0
+    @test constraint(o, :eq3)(z) == z[1]
+    @test o.dynamics(x, u, z) == [ x[2], x[1]^2 + z[1] ]
+    @test o.lagrange(x, u, z) == u[1]^2 + z[1] * x[1]
+
 end
 
 end


### PR DESCRIPTION
- Seems that `->` does not work. I have let `=>`.
- I have added `in` equivalent to `∈`.
- We have:

```julia
julia> @def o begin
               z in R, variable
               t in [ 0, 1 ], time
               x in R^2, state
               u in R, control
               r = x1
               v = x2
               0 <= r(0) - z <= 1,            (1)
               0 <= v(1)^2 <= 1,              (2)
               [ 0, 0 ] <= x(0) <= [ 1, 1 ],  (♡)
               z >= 0,                        (3)
               derivative(x)(t) == [ v(t), r(t)^2 + z ]
               integral( u(t)^2 + z * x1(t) ) => min
           end
ERROR: ParsingError: 
Line 8: (0 ≤ v(1) ^ 2 ≤ 1, 2)
bad constraint declaration
```

because of `v = x2`. Do we accept this kind of aliases? It means that we need `x1`, `x2`, ..., automatically.