### PR TITLE
docs: update changelog and breakings for v0.18.7

### DIFF
--- a/BREAKINGS.md
+++ b/BREAKINGS.md
@@ -15,6 +15,13 @@ This document outlines all breaking changes introduced in CTBase v0.18.0-beta co
 
 ---
 
+## Non-breaking note (0.18.7)
+
+- **Version stabilization**: Bumped from 0.18.6-beta to 0.18.7 for stable release. No functional changes; version promotion only.
+- **Code formatting**: Applied JuliaFormatter to ensure consistent code style across the codebase. No functional changes; formatting only.
+- **CI improvements**: Enhanced CompatHelper workflow with subdirs input for better dependency management. No functional changes; CI infrastructure only.
+- No breaking changes. No migration required.
+
 ## Non-breaking note (0.18.6-beta)
 
 - **Documenter Color Support**: Added ANSI escape sequence support for exception display colors in generated documentation. Replaced `printstyled` calls with ANSI equivalents to enable automatic conversion to CSS classes by Documenter. No API changes; purely internal implementation improvement. No migration required.

--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -5,6 +5,25 @@ All notable changes to CTBase will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.7] - 2026-03-31
+
+### 🧹 Maintenance
+
+#### **Version Stabilization**
+
+- **Stable release**: Bumped from 0.18.6-beta to 0.18.7 for stable release
+- **No functional changes**: Version promotion only, all features from 0.18.6-beta preserved
+
+#### **Code Quality**
+
+- **Code formatting**: Applied JuliaFormatter across the codebase for consistent style
+- **Standardized formatting**: Improved readability and maintainability
+
+#### **Infrastructure**
+
+- **CI improvements**: Enhanced CompatHelper workflow with subdirs input
+- **Better dependency management**: More robust compatibility checking
+
 ## [0.18.6-beta] - 2026-03-17
 
 ### 🛠 Enhancements


### PR DESCRIPTION
- Add changelog entry for version stabilization from 0.18.6-beta
- Document JuliaFormatter application for code consistency
- Note CompatHelper workflow improvements
- Update BREAKINGS.md with non-breaking note for v0.18.7