### PR TITLE
feat: add configurable report limits to postprocess_coverage

### DIFF
--- a/ext/CoveragePostprocessing.jl
+++ b/ext/CoveragePostprocessing.jl
@@ -31,6 +31,8 @@ This implementation:
 - `generate_report::Bool=true`: If `true`, write `coverage/lcov.info` and `coverage/cov_report.md`.
 - `root_dir::String=pwd()`: Root directory of the project.
 - `dest_dir::String="coverage"`: Destination directory for coverage artifacts.
+- `worst_n_files::Int=20`: Maximum number of lowest-covered files to list in the report.
+- `max_uncovered_lines::Int=200`: Maximum number of uncovered lines to display in the report.
 
 # Returns
 
@@ -53,7 +55,13 @@ function CTBase.postprocess_coverage(
     generate_report::Bool=true,
     root_dir::String=pwd(),
     dest_dir::String="coverage",
+    worst_n_files::Int=20,
+    max_uncovered_lines::Int=200,
 )
+    # Validate report limits
+    worst_n_files > 0 || throw(CTBase.Exceptions.IncorrectArgument("worst_n_files must be > 0, got $(worst_n_files)"))
+    max_uncovered_lines > 0 || throw(CTBase.Exceptions.IncorrectArgument("max_uncovered_lines must be > 0, got $(max_uncovered_lines)"))
+
     println("✓ Coverage post-processing start")
 
     # Define paths relative to root_dir
@@ -91,7 +99,7 @@ function CTBase.postprocess_coverage(
     n_cov == 0 &&
         error("Coverage requested but no usable .cov files were found after cleanup.")
 
-    generate_report && _generate_coverage_reports!(source_dirs, coverage_dir, root_dir)
+    generate_report && _generate_coverage_reports!(source_dirs, coverage_dir, root_dir, worst_n_files, max_uncovered_lines)
 
     moved = _collect_and_move_cov_files!(source_dirs, cov_storage_dir)
     isempty(moved) && error("Coverage requested but no .cov files were found to move.")
@@ -220,16 +228,23 @@ function _collect_and_move_cov_files!(source_dirs, dest_dir)
 end
 
 """
-    _generate_coverage_reports!(source_dirs, coverage_dir, root_dir)
+    _generate_coverage_reports!(source_dirs, coverage_dir, root_dir, worst_n_files, max_uncovered_lines)
 
 Internal helper that generates coverage reports from `.cov` files.
+
+# Arguments
+- `source_dirs::Vector{String}`: Directories to scan for `.cov` files.
+- `coverage_dir::String`: Destination directory for reports.
+- `root_dir::String`: Project root directory for path resolution.
+- `worst_n_files::Int`: Maximum number of lowest-covered files to list in the report.
+- `max_uncovered_lines::Int`: Maximum number of uncovered lines to display in the report.
 
 Writes:
 
 - `coverage/lcov.info`
 - `coverage/cov_report.md`
 """
-function _generate_coverage_reports!(source_dirs, coverage_dir, root_dir)
+function _generate_coverage_reports!(source_dirs, coverage_dir, root_dir, worst_n_files, max_uncovered_lines)
     println("✓ Generating coverage report")
 
     # Process source directories for coverage
@@ -305,25 +320,25 @@ function _generate_coverage_reports!(source_dirs, coverage_dir, root_dir)
         end
         println(io, "```\n")
 
-        println(io, "## Lowest-covered files (top 20)\n")
+        println(io, "## Lowest-covered files (top $(worst_n_files))\n")
         println(io, "| file | covered | total | % |")
         println(io, "|---|---:|---:|---:|")
-        for (f, h, t, p) in rows[1:min(end, 20)]
+        for (f, h, t, p) in rows[1:min(end, worst_n_files)]
             rel_f = relative_path(f, root_dir)
             println(io, "| `", rel_f, "` | ", h, " | ", t, " | ", round(p; digits=2), " |")
         end
         println(io)
 
-        println(io, "## Uncovered lines (first 200)\n\n```shell")
+        println(io, "## Uncovered lines (first $(max_uncovered_lines))\n\n```shell")
         n = 0
         for fc in cov
             rel_filename = relative_path(fc.filename, root_dir)
             for i in findall(v -> (v isa Integer) && v == 0, fc.coverage)
                 println(io, rel_filename, ":", i)
                 n += 1
-                n >= 200 && break
+                n >= max_uncovered_lines && break
             end
-            n >= 200 && break
+            n >= max_uncovered_lines && break
         end
         println(io, "```")
         return nothing

--- a/src/Extensions/Extensions.jl
+++ b/src/Extensions/Extensions.jl
@@ -166,6 +166,8 @@ is loaded.
 - `generate_report::Bool=true`: Whether to generate summary reports.
 - `root_dir::String=pwd()`: Project root directory used to locate coverage artifacts.
 - `dest_dir::String="coverage"`: Destination directory for coverage artifacts.
+- `worst_n_files::Int=20`: Maximum number of lowest-covered files to list in the report.
+- `max_uncovered_lines::Int=200`: Maximum number of uncovered lines to display in the report.
 
 # Throws
 
@@ -183,6 +185,8 @@ function postprocess_coverage(
     generate_report::Bool=true,
     root_dir::String=pwd(),
     dest_dir::String="coverage",
+    worst_n_files::Int=20,
+    max_uncovered_lines::Int=200,
 )
     throw(
         Exceptions.ExtensionError(

--- a/test/coverage.jl
+++ b/test/coverage.jl
@@ -12,6 +12,16 @@
 #   julia --project=@. -e 'using Pkg; Pkg.test("CTBase"; coverage=true); include("test/coverage.jl")'
 #
 # ==============================================================================
+
+# Report configuration
+const WORST_N_FILES = 20
+const MAX_UNCOVERED_LINES = 200
+
 using Coverage
 using CTBase
-CTBase.postprocess_coverage(; root_dir=dirname(@__DIR__), dest_dir=".coverage")
+CTBase.postprocess_coverage(;
+    root_dir=dirname(@__DIR__),
+    dest_dir=".coverage",
+    worst_n_files=WORST_N_FILES,
+    max_uncovered_lines=MAX_UNCOVERED_LINES,
+)

--- a/test/suite/extensions/test_coverage_post_process.jl
+++ b/test/suite/extensions/test_coverage_post_process.jl
@@ -1,3 +1,4 @@
+# TOP-LEVEL: Fake type for stub testing
 struct DummyCoverageTag <: CTBase.Extensions.AbstractCoveragePostprocessingTag end
 
 function test_coverage_post_process()
@@ -151,7 +152,7 @@ function test_coverage_post_process()
 """,
                 )
 
-                CP._generate_coverage_reports!(["src"], joinpath(tmp, "coverage"), tmp)
+                CP._generate_coverage_reports!(["src"], joinpath(tmp, "coverage"), tmp, 20, 200)
 
                 @test isfile(joinpath("coverage", "lcov.info"))
                 @test isfile(joinpath("coverage", "cov_report.md"))
@@ -176,7 +177,7 @@ function test_coverage_post_process()
 
                 mkpath(joinpath(root, "coverage"))
                 CP._generate_coverage_reports!(
-                    [joinpath(other, "src")], joinpath(root, "coverage"), root
+                    [joinpath(other, "src")], joinpath(root, "coverage"), root, 20, 200
                 )
 
                 report = read(joinpath(root, "coverage", "cov_report.md"), String)
@@ -237,6 +238,143 @@ function test_coverage_post_process()
                 catch e
                     # This should not error in normal circumstances
                 end
+            end
+        end
+    end
+
+    @testset "Report limits - default behavior" begin
+        mktempdir() do tmp
+            cd(tmp) do
+                mkpath("src")
+                mkpath("coverage")
+
+                write(joinpath("src", "a.jl"), "a(x) = x\n")
+                write(joinpath("src", "b.jl"), "b(x) = x\n")
+                write(joinpath("src", "c.jl"), "c(x) = x\n")
+
+                write(joinpath("src", "a.jl.1234.cov"), """
+        -:    1:a(x) = x
+        0:    2:a(1)
+""")
+                write(joinpath("src", "b.jl.1234.cov"), """
+        -:    1:b(x) = x
+        0:    2:b(1)
+""")
+                write(joinpath("src", "c.jl.1234.cov"), """
+        -:    1:c(x) = x
+        0:    2:c(1)
+""")
+
+                CTBase.postprocess_coverage(; generate_report=true)
+
+                report = read(joinpath("coverage", "cov_report.md"), String)
+                @test occursin("top 20", report)
+                @test occursin("first 200", report)
+            end
+        end
+    end
+
+    @testset "Report limits - custom worst_n_files" begin
+        mktempdir() do tmp
+            cd(tmp) do
+                mkpath("src")
+                mkpath("coverage")
+
+                write(joinpath("src", "a.jl"), "a(x) = x\n")
+                write(joinpath("src", "b.jl"), "b(x) = x\n")
+                write(joinpath("src", "c.jl"), "c(x) = x\n")
+
+                write(joinpath("src", "a.jl.1234.cov"), """
+        -:    1:a(x) = x
+        0:    2:a(1)
+""")
+                write(joinpath("src", "b.jl.1234.cov"), """
+        -:    1:b(x) = x
+        0:    2:b(1)
+""")
+                write(joinpath("src", "c.jl.1234.cov"), """
+        -:    1:c(x) = x
+        0:    2:c(1)
+""")
+
+                CTBase.postprocess_coverage(; generate_report=true, worst_n_files=1)
+
+                report = read(joinpath("coverage", "cov_report.md"), String)
+                @test occursin("top 1", report)
+                @test !occursin("top 20", report)
+            end
+        end
+    end
+
+    @testset "Report limits - custom max_uncovered_lines" begin
+        mktempdir() do tmp
+            cd(tmp) do
+                mkpath("src")
+                mkpath("coverage")
+
+                write(joinpath("src", "a.jl"), "a(x) = x\n")
+                write(joinpath("src", "a.jl.1234.cov"), """
+        -:    1:a(x) = x
+        0:    2:a(1)
+        0:    3:a(2)
+        0:    4:a(3)
+""")
+
+                CTBase.postprocess_coverage(; generate_report=true, max_uncovered_lines=2)
+
+                report = read(joinpath("coverage", "cov_report.md"), String)
+                @test occursin("first 2", report)
+                @test !occursin("first 200", report)
+            end
+        end
+    end
+
+    @testset "Report limits - invalid options" begin
+        mktempdir() do tmp
+            cd(tmp) do
+                mkpath("src")
+                mkpath("test")
+                mkpath("ext")
+
+                write(joinpath("src", "a.jl.1234.cov"), """
+        -:    1:a(x) = x
+""")
+
+                err = try
+                    CTBase.postprocess_coverage(; generate_report=false, worst_n_files=0)
+                    nothing
+                catch e
+                    e
+                end
+                @test err isa CTBase.Exceptions.IncorrectArgument
+                @test occursin("worst_n_files must be > 0", err.msg)
+
+                err = try
+                    CTBase.postprocess_coverage(; generate_report=false, worst_n_files=-5)
+                    nothing
+                catch e
+                    e
+                end
+                @test err isa CTBase.Exceptions.IncorrectArgument
+                @test occursin("worst_n_files must be > 0", err.msg)
+
+                err = try
+                    CTBase.postprocess_coverage(; generate_report=false, max_uncovered_lines=0)
+                    nothing
+                catch e
+                    e
+                end
+                @test err isa CTBase.Exceptions.IncorrectArgument
+                @test occursin("max_uncovered_lines must be > 0", err.msg)
+
+                err = try
+                    CTBase.postprocess_coverage(; generate_report=false, max_uncovered_lines=-10)
+                    nothing
+                catch e
+                    e
+                end
+                @test err isa CTBase.Exceptions.IncorrectArgument
+                @test occursin("max_uncovered_lines must be > 0", err.msg)
             end
         end
     end


### PR DESCRIPTION
Add worst_n_files and max_uncovered_lines options to control coverage report output. Defaults maintain backward compatibility (20 files, 200 lines). Added validation for invalid values and comprehensive tests.